### PR TITLE
added crowdranking oembed endpoint

### DIFF
--- a/providers.json
+++ b/providers.json
@@ -264,5 +264,16 @@
             ".*\\.wistia.com/medias/.*"
         ],
         "endpoint": "http://fast.wistia.com/oembed.{format}"
+    },
+    {
+        "name": "crowdranking",
+        "templates": [
+            "crowdranking.com/crowdrankings/.+",
+            "crowdranking.com/rankings/.+",
+            "crowdranking.com/topics/.+",
+            "crowdranking.com/widgets/.+",
+            "crowdranking.com/r/.+"
+        ],
+        "endpoint": "http://crowdranking.com/api/oembed.{format}"
     }
 ]


### PR DESCRIPTION
This endpoint supports `xml`, `json` and `jsonp`. `js` or `json` with and `callback` parameter are also treated as `jsonp`.
Supported parameters are: `maxwidth`, `maxheight` and `lang`. There are other service specific parameters that I have to document some day.

It returns the type `rich` with `html` containing an iframe. `maxwidth` and `maxheight` are used for the width and height of the iframe and default to 250x500. The endpoint also returns an `url` that points to the iframe source and two attributes I "stole" from flickr: `web_page` (a link to the ranking on crowdranking.com) and `web_page_short_url` (short-ish; this url might get shorter in the future).
