### PR TITLE
Magnatune Plugin

### DIFF
--- a/plugins/domains/magnatune.com.js
+++ b/plugins/domains/magnatune.com.js
@@ -12,7 +12,7 @@ module.exports = {
 		"favicon"
 	],
 
-	getData: function(url, urlMatch, meta, $selector) {
+	getData: function(url, urlMatch, meta) {
 		var image_url = URL.parse(meta.og.image);
 		var image_path = image_url.path.split("/");
 
@@ -20,16 +20,12 @@ module.exports = {
 		var author = decodeURIComponent(image_path[2]);
 		var title  = decodeURIComponent(image_path[3]);
 
-		var $author  = $selector('a[rel="cc:attributionURL"]');
-		var $license = $selector('a[rel="license"]');
-
 		return {
 			magnatune_meta: {
 				title:       title,
 				author:      author,
-				author_url:  URL.resolve(url, $author.attr('href')),
-				license:     $license.attr('title'),
-				license_url: URL.resolve(url, $license.attr('href')),
+				license:     "All audio files at Magnatune are licensed under the Creative Commons Attribution-NonCommercial-ShareAlike license.",
+				license_url: "http://magnatune.com/info/cc_licensed",
 				embed_url:   "http://embed.magnatune.com/img/magnatune_player_embedded.swf?playlist_url=http://embed.magnatune.com/artists/albums/"+
 				             urlMatch[1]+"/hifi.xspf&autoload=true&autoplay=&playlist_title="+encodeURIComponent(author+" : "+title)
 			}


### PR DESCRIPTION
I wrote this plugin for [Magnatune](http://magnatune.com/). I'm not sure if I did everything as expected. E.g. I return the cover image in all available resolutions (marking those < 300x300 as thumbnails), I have to do redundant things between `getMeta` and `getLink` (it would be nice if `getMeta` would be executed before `getLink`) and `html_for_readability` contains the headline (should it? shouldn't it?).

Further I have to note that `embed.magnatune.com` does not set the correct content type of the swf file and so it only works when embedded using an `object` or `embed` tag, but not using an `iframe` tag. I wrote to John Buckman (the main guy behind Magnatune) about this yesterday but haven't received a reply yet. I hope he'll fix it soon. Maybe this shouldn't be merged before it is fixed? Or is there another (secure) way to embed a flash plugin with this tool?
