### PR TITLE
fixed google maps regexp

### DIFF
--- a/plugins/domains/maps.google.com.js
+++ b/plugins/domains/maps.google.com.js
@@ -11,7 +11,7 @@ var TypeMap = {
 
 module.exports = {
 
-    re: /^https?:\/\/maps\.google\.(?:com?\.)?[a-z]+\/maps(?:\/ms)?\?.+/i,
+    re: /^https?:\/\/maps\.google\.(?:com?\.)?[a-z]+\/(?:maps(?:\/ms)?)?\?.+/i,
 
     mixins: [
         'html-title',


### PR DESCRIPTION
This was the reason the plugin stopped working for me. Even the `maps` is optional and in fact omitted when you make a permalink. In case you wonder, the `/ms` part is for saved maps (with markers and whatnot on them).
