### PR TITLE
OpenStreetMap Plugin

### DIFF
--- a/plugins/domains/openstreetmap.org.js
+++ b/plugins/domains/openstreetmap.org.js
@@ -87,7 +87,7 @@ module.exports = {
 			links.push({
 				href: "http://staticmap.openstreetmap.de/staticmap.php?"+
 					"center="+lat+","+lon+"&"+
-					"zoom="+zoom+"&"+
+					"zoom="+Math.max(0,zoom-1)+"&"+
 					"size="+thumb_width+"x"+thumb_height+"&"+
 					"maptype="+layer,
 				rel:  CONFIG.R.thumbnail,


### PR DESCRIPTION
I've more or less randomly chosen 640x480 for the iframe and 320x240 for the thumbnail. I could change this values to anything, but even though the iframe could be arbitrarily resized I need to know it's size to calculate it's bounding box. Hmm, but actually you _can_ ignore the size of the iframe. OSM will center the view and adjust the zoom dynamically so the shown proportion fits. So the 640x480 value is actually just an assumption on how big the map was viewed when the URL was taken and thus I could leave out the width/height values for the iframe altogether.
