### PR TITLE
only parse exported functions and error out if there is an unrecoverable error

### DIFF
--- a/lib/iframely.js
+++ b/lib/iframely.js
@@ -1293,24 +1293,29 @@
         return filenameWithExt.replace(/\.(js|ejs)$/i, "");
     }
 
-    function getPluginMethods(pluginPath) {
-
+    function getPluginMethods(pluginPath,plugin) {
         var methods = {};
-
-        var file = fs.readFileSync(pluginPath, "utf8");
-        JSLINT(file, {node: true});
-        var data = JSLINT.data();
-
-        data.functions.filter(function(func) {
-            func._name = func.name.replace(/'(.+)'/, "$1");
-            return PLUGIN_METHODS.indexOf(func._name) > -1;
-        }).forEach(function(func) {
-                var params = methods[func._name] = [];
-                func.params.forEach(function(param) {
-                    params.push(param.string);
+        for (var name in plugin) {
+            var func = plugin[name];
+            if (typeof func === "function" && PLUGIN_METHODS.indexOf(name) > -1) {
+                JSLINT('('+String(func)+')', {node: true, sloppy: true, white: true, vars: true, maxerr: Infinity, forin: true});
+                if (!JSLINT.tree.first) {
+                    console.error('In file '+pluginPath+' in function exports.'+name+':');
+                    JSLINT.data().errors.forEach(function (error) {
+                        if (error) {
+                            console.error(error.reason);
+                            if (error.evidence) {
+                                console.error(error.evidence+'\n');
+                            }
+                        }
+                    });
+                    throw new Error('JSLINT could not parse function');
+                }
+                methods[name] = JSLINT.tree.first[0].first.map(function (param) {
+                    return param.string;
                 });
-            });
-
+            }
+        }
         return methods;
     }
 
@@ -1429,7 +1434,7 @@
             }
 
             // Find plugin methods params.
-            pluginDeclaration.methods = getPluginMethods(pluginPath);
+            pluginDeclaration.methods = getPluginMethods(pluginPath,plugin);
             for(var method in pluginDeclaration.methods) {
                 if (!(method in plugin)) {
                     delete pluginDeclaration.methods[method];

--- a/plugins/generic/favicon.js
+++ b/plugins/generic/favicon.js
@@ -3,12 +3,13 @@ module.exports = {
     getLinks: function(meta) {
 
         function findIcons(links, filter) {
+            var key, l;
 
-            for(var key in meta) {
+            for(key in meta) {
 
                 if (filter(key)) {
 
-                    var l = meta[key];
+                    l = meta[key];
 
                     if (!(l instanceof Array)) {
                         l = [l];

--- a/plugins/generic/meta/dc.js
+++ b/plugins/generic/meta/dc.js
@@ -4,16 +4,16 @@ module.exports = {
 
         function getAttr(attr) {
 
-            var root = meta.dc || meta.dcterms;
+            var root = meta.dc || meta.dcterms, key;
             if (root && root[attr]) {
-                for(var key in root) {
+                for(key in root) {
                     if (key == attr) {
                         return root[key];
                     }
                 }
             }
 
-            for(var key in meta) {
+            for(key in meta) {
                 var bits = key.split('.');
                 if (bits.length > 1) {
                     var b0 = bits[0];


### PR DESCRIPTION
The way JSLINT was used produced silent errors and caused me some headache during debugging. If you just use `JSLINT.data().functions` you will find functions that aren't exported (in theory there could be an arbitrary number of `getLink` functions in a module, just only one in `exports`) and more importantly JSLINT will **stop parsing** if it encounters to many errors or a certain kind of error (that isn't an error at all for any compliant JavaScript parser -- JSLINT is much more strict that strict mode).

So I changed it so that only the exported functions are parsed and I throw an error if it couldn't parse the function at all (which was the case for functions in `favicon.js` and `dc.js` -- I wonder how these even worked). I don't error out on any error that is reported by JSLINT (that would be too much, even if I pass a lot of relaxing options), but only on those where it couldn't parse the function at all.

Off topic: I often saw code like this in the source:

``` javascript
var ys = [];
xs.forEach(function (x) { ys.push(f(x)); });
```

Why not write it like this?

``` javascript
var ys = xs.map(function (x) { return f(x); });
```
