### PR TITLE
Cross site scripting/HTML code injection vulnerability

### DIFF
--- a/static/js/debug.js
+++ b/static/js/debug.js
@@ -1,9 +1,17 @@
 function linkify(text) {
     if (typeof text === "string") {
-        return text.replace(/((https?:)?\/\/[^"\s]+)/gi, '<a target="_blank" href="$1">$1</a>');
+        return text.replace(/((https?:)?\/\/[^"'<>\s]+)/gi, '<a target="_blank" href="$1">$1</a>');
     } else {
         return text;
     }
+}
+
+var HTML_CHARS = {'"':"&quot;","'":"&#39;","&":"&amp;","<":"&lt;",">":"&gt;"};
+
+function escapeHtml(text) {
+    return String(text).replace(/["'&<>]/g, function (ch) {
+        return HTML_CHARS[ch];
+    });
 }
 
 // Render json in PRE.
@@ -42,7 +50,7 @@ $.fn.renderObject = function(o) {
     var text = JSON.stringify(createTrimmedObject(o), null, 4);
     text = $('<div>').text(text).html();
     text = text.replace(/\\"/gi, '"');
-    text = text.replace(/"((https?:)?\/\/[^"\s]+)"/gi, '"<a target="_blank" href="$1">$1</a>"');
+    text = text.replace(/"((https?:)?\/\/[^"'<>\s]+)"/gi, '"<a target="_blank" href="$1">$1</a>"');
     text = text.replace(/\[contextLink](\w+)\[\/contextLink\]/gi, '<a href="#" data-context-link="$1">$1</a>');
     this.html(text);
     return this;
@@ -217,7 +225,7 @@ function showEmbeds($embeds, data, filterByRel) {
                         head = debug.plugin;
                     }
                 }
-                $embeds.append('<h2 data-plugin="' + debug.plugin + '-' + counter + '">' + head + '</h2>');
+                $embeds.append('<h2 data-plugin="' + debug.plugin + '-' + counter + '">' + escapeHtml(head) + '</h2>');
                 counter += 1;
 
                 // Links preview.
@@ -292,7 +300,7 @@ function showEmbeds($embeds, data, filterByRel) {
 
             var method = plugin.methods[data.meta._sources[key].method];
 
-            $meta.append('<tr>' + (DEBUG ? ('<td>' + plugin.id + '</td><td>' + method.join(', ') + '</td>') : '') + '<td><strong>' + key + '</strong></td><td>' + linkify(data.meta[key]) + '</td></tr>')
+            $meta.append('<tr>' + (DEBUG ? ('<td>' + escapeHtml(plugin.id) + '</td><td>' + escapeHtml(method.join(', ')) + '</td>') : '') + '<td><strong>' + escapeHtml(key) + '</strong></td><td>' + linkify(escapeHtml(data.meta[key])) + '</td></tr>')
         });
 
         $embeds.prepend($meta);
@@ -302,7 +310,7 @@ function showEmbeds($embeds, data, filterByRel) {
         var $textarea = $('<textarea>')
             .hide()
             .attr('rows', pluginsList.length + 2)
-            .html("mixins: " + JSON.stringify(pluginsList, null, 4));
+            .html("mixins: " + escapeHtml(JSON.stringify(pluginsList, null, 4)));
 
         var $a = $('<a href="#">')
             .text('[show plugins as mixins]')

--- a/views/debug/index.ejs
+++ b/views/debug/index.ejs
@@ -29,7 +29,7 @@
                 Bookmarklet:
                 <a style="padding: 2px; border: solid grey 1px;" onclick="return false;" href="javascript: var win=window.open('<%- CONFIG.baseAppUrl %>/debug?uri='+encodeURIComponent(document.location.href),'_blank');win.focus();">debug&nbsp;in&nbsp;iframe.ly</a>
                 <br>
-                You can drag&drop it to your bookmarks to test web pages quickly with iframely.
+                You can drag&amp;drop it to your bookmarks to test web pages quickly with iframely.
             <p>
             <p style="padding: 5px;">
                 <a href="/meta-mappings" target="_blank">Unified META mappings</a>


### PR DESCRIPTION
Displayed values under `/debug` aren't HTML-escaped. E.g. this opens an alert showing the text "powned":
http://iframely.com/debug?uri=http%3A%2F%2Ffiddle.jshell.net%2FGDkAj%2F1%2Fshow%2F

This commit fixes these issues, but I don't guarantee that there aren't any others. There is a lot of HTML-building in `debug.js` that uses string concatenation, but I *think* the remaining cases don't contain values from the extracted website.