### PR TITLE
get plugin methods without need for JSLINT

### DIFF
--- a/lib/iframely.js
+++ b/lib/iframely.js
@@ -6,7 +6,6 @@
 
     var fs = require('fs'),
         path = require('path'),
-        JSLINT = require('jslint'),
         _ = require('underscore'),
         async = require('async'),
         request = require('request'),
@@ -1293,23 +1292,21 @@
         return filenameWithExt.replace(/\.(js|ejs)$/i, "");
     }
 
-    function getPluginMethods(pluginPath) {
+    function getPluginMethods(plugin) {
 
         var methods = {};
+        // strip comments (only correctly works in function declearation before {
+        // because there can be no string literals that e.g. contain " /* "):
+        var re = /\/\/[^\r\n]*|\/\*(?:[\r\n]|[^\*]|\*[^\/]|\*$)*\*\//ig;
 
-        var file = fs.readFileSync(pluginPath, "utf8");
-        JSLINT(file, {node: true});
-        var data = JSLINT.data();
-
-        data.functions.filter(function(func) {
-            func._name = func.name.replace(/'(.+)'/, "$1");
-            return PLUGIN_METHODS.indexOf(func._name) > -1;
-        }).forEach(function(func) {
-                var params = methods[func._name] = [];
-                func.params.forEach(function(param) {
-                    params.push(param.string);
+        for (var name in plugin) {
+            var func = plugin[name];
+            if (typeof func === "function" && PLUGIN_METHODS.indexOf(name) > -1) {
+                methods[name] = String(func).replace(re,'').split(/[()]/g,2)[1].split(',').map(function (arg) {
+                    return arg.trim();
                 });
-            });
+            }
+        }
 
         return methods;
     }
@@ -1429,7 +1426,7 @@
             }
 
             // Find plugin methods params.
-            pluginDeclaration.methods = getPluginMethods(pluginPath);
+            pluginDeclaration.methods = getPluginMethods(plugin);
             for(var method in pluginDeclaration.methods) {
                 if (!(method in plugin)) {
                     delete pluginDeclaration.methods[method];


### PR DESCRIPTION
This always works because the function is garanteed to be
syntactically correct once it is parsed by nodejs, so I only
need to strip comments and "parse" the argument names.