### PR TITLE
fix Magnatune plugin

### DIFF
--- a/plugins/domains/magnatune.com.js
+++ b/plugins/domains/magnatune.com.js
@@ -18,11 +18,11 @@ module.exports = {
         var author = html_title[1].replace(/\s*\(listen for free\)\s*$/, '').trim();
         var sku    = urlMatch[1];
 
-		if (urlMatch[2] === 'lofi_play') {
-			var tmp = author;
-			author = title;
-			title  = tmp;
-		}
+        if (urlMatch[2] === 'lofi_play') {
+            var tmp = author;
+            author = title;
+            title  = tmp;
+        }
 
         return {
             magnatune_meta: {

--- a/plugins/domains/magnatune.com.js
+++ b/plugins/domains/magnatune.com.js
@@ -8,19 +8,15 @@ module.exports = {
     ],
 
     mixins: [
-        "og-description",
-        "og-image",
         "favicon"
     ],
 
-    getData: function(url, urlMatch, meta) {
+    getData: function(urlMatch, meta) {
 
-        var image_url = URL.parse(meta.og.image);
-        var image_path = image_url.path.split("/");
-
+        var html_title = meta['html-title'].split(/\s*:\s+/);
+        var title  = html_title[0].trim();
+        var author = html_title[1].replace(/\s*\(listen for free\)\s*$/, '').trim();
         var sku    = urlMatch[1];
-        var author = decodeURIComponent(image_path[2]);
-        var title  = decodeURIComponent(image_path[3]);
 
         return {
             magnatune_meta: {

--- a/plugins/domains/magnatune.com.js
+++ b/plugins/domains/magnatune.com.js
@@ -4,7 +4,7 @@ var jQuery = require("jquery");
 module.exports = {
 
     re: [
-        /^http:\/\/magnatune\.com\/artists\/albums\/([-_a-z0-9]+)(?:\/(?:lofi_play)?)?(?:[\?#].*)?$/i
+        /^http:\/\/magnatune\.com\/artists\/albums\/([-_a-z0-9]+)(?:\/(lofi_play)?)?(?:[\?#].*)?$/i
     ],
 
     mixins: [
@@ -17,6 +17,12 @@ module.exports = {
         var title  = html_title[0].trim();
         var author = html_title[1].replace(/\s*\(listen for free\)\s*$/, '').trim();
         var sku    = urlMatch[1];
+
+		if (urlMatch[2] === 'lofi_play') {
+			var tmp = author;
+			author = title;
+			title  = tmp;
+		}
 
         return {
             magnatune_meta: {


### PR DESCRIPTION
Magnatune changed it's layout and dropped all meta data. Therefore this plugin can no longer extract the album description from the open graph meta data. I could extract it from the html body. Should I?

Anyway, the new html is horribly broken (not doctype, no </head>, lot's of deprecated old tags/attributes, script elements between </body> and </html> etc.). It's a wonder the site works as good as it does.