### PR TITLE
open street map: parse new url scheme (#hash) and embed urls

### DIFF
--- a/plugins/domains/openstreetmap.org.js
+++ b/plugins/domains/openstreetmap.org.js
@@ -1,10 +1,19 @@
 var URL = require("url");
+var QueryString = require("querystring");
 
 var LayerMap = {
     M: 'mapnik',
+    O: 'mapnik', // osma render is no longer supported
     C: 'cyclemap',
     T: 'transportmap',
     Q: 'mapquest'
+};
+
+var ReverseLayerMap = {
+    mapnik:       'M',
+    cyclemap:     'C',
+    transportmap: 'T',
+    mapquest:     'Q'
 };
 
 function sinh(x) {
@@ -46,7 +55,7 @@ function getBBox(lat, lon, zoom, width, height) {
 
 module.exports = {
 
-    re: /^https?:\/\/(?:www\.)?openstreetmap\.org\/\?.+/i,
+    re: /^https?:\/\/(?:www\.)?openstreetmap\.org\/(?:\?.+|\#.*map=.+|export\/embed\.html\?)/i,
 
     mixins: [
         'html-title',
@@ -54,50 +63,153 @@ module.exports = {
     ],
 
     getLink: function(url) {
-        var query = URL.parse(url, true).query;
-        var links = [];
+        // Currently the notes and data layers aren't used in embeds and static maps,
+        // but who knows, maybe that'll change?
+        var layers, layer, zoom, lat, lon, bbox, marker, notes = false, data = false;
 
-        if (query.lat && query.lon) {
-            var embed_width  = 640;
-            var embed_height = 480;
+        url = URL.parse(url, true);
 
-            var thumb_width  = 320;
-            var thumb_height = 240;
+        // parse query string
+        var query = url.query;
 
-            var lat = Number(query.lat);
-            var lon = Number(query.lon);
-            var zoom = isNaN(query.zoom) ? 10 : Math.floor(Number(query.zoom));
-            if (zoom < 0)       zoom =  0;
-            else if (zoom > 18) zoom = 18;
+        layer  = query.layer;
+        layers = query.layers;
+        zoom   = Number(query.zoom);
 
-            var bbox  = getBBox(lat, lon, zoom, embed_width, embed_height);
-            var layer = query.layers && LayerMap[query.layers.charAt(0)] || 'mapnik';
+        // lat & lon
+        if ('lat' in query) lat = Number(query.lat);
+        if ('lon' in query) lon = Number(query.lon);
 
-            // There is no encodeURIComponent or similar used on purpose, because
-            // OpenStreetMap wants the ',' of the bbox parameter unencoded!
-            links.push({
-                href: "http://www.openstreetmap.org/export/embed.html?bbox="+
-                      bbox.join(',')+'&layer='+layer,
-                rel:  CONFIG.R.reader,
-                type: CONFIG.T.text_html,
-                width:  embed_width,
-                height: embed_height
-            });
-
-            links.push({
-                href: "http://staticmap.openstreetmap.de/staticmap.php?"+
-                    "center="+lat+","+lon+"&"+
-                    "zoom="+Math.max(0,zoom-1)+"&"+
-                    "size="+thumb_width+"x"+thumb_height+"&"+
-                    "maptype="+layer,
-                rel:  CONFIG.R.thumbnail,
-                type: CONFIG.T.image_png,
-                width:  thumb_width,
-                height: thumb_height
-            });
+        // bounding box
+        if ('minlat' in query && 'minlon' in query && 'maxlat' in query && 'maxlon' in query) {
+            bbox = [Number(query.minlon), Number(query.minlat),
+                    Number(query.maxlon), Number(query.maxlat)];
+        }
+        else if ('bbox' in query) {
+            bbox = query.bbox.split(',',4).map(Number);
         }
 
-        return links;
+        if (bbox && bbox.some(isNaN)) {
+            bbox = undefined;
+        }
+
+        // marker
+        if ('mlon' in query && 'mlat' in query) {
+            marker = [Number(query.mlat), Number(query.mlon)];
+        }
+
+        // parse hash
+        query = QueryString.parse((url.hash||'').replace(/^#/,''));
+
+        if (query.map) {
+            if ('layers' in query) {
+                layers = query.layers;
+            }
+
+            // zoom, lat & lon
+            var map = query.map.split('/');
+            zoom = Number(map[0]);
+            lat  = Number(map[1]);
+            lon  = Number(map[2]);
+
+            if (!isNaN(lat) && !isNaN(lon)) {
+                // hash overwrites query
+                bbox = undefined;
+            }
+        }
+
+        // lat & lon from marker if not otherwise defined
+        if (isNaN(lat) || isNaN(lon)) {
+            if (bbox) {
+                // XXX: this might fail when bbox spans over coordinate system boundaries
+                lon = (bbox[0] + bbox[2]) * 0.5;
+                lat = (bbox[1] + bbox[3]) * 0.5;
+            }
+
+            if (marker) {
+                lat = marker[0];
+                lon = marker[1];
+            }
+        }
+
+        if (isNaN(lat) || isNaN(lon)) {
+            return [];
+        }
+
+        var embed_width  = 640;
+        var embed_height = 480;
+
+        // musst be > 40x40 to work
+        var thumb_width  = 320;
+        var thumb_height = 240;
+
+        // parse extra layers
+        if (layers) {
+            if (layers.indexOf('N') >= 0) {
+                notes  = true;
+                layers = layers.replace(/N/g,'');
+            }
+
+            if (layers.indexOf('D') >= 0) {
+                data   = true;
+                layers = layers.replace(/D/g,'');
+            }
+        }
+
+        if (layer && ReverseLayerMap.hasOwnProperty(layer)) {
+            // ok
+        }
+        else if (layers && LayerMap.hasOwnProperty(layers)) {
+            layer = LayerMap[layers];
+        }
+        else {
+            layer = 'mapnik';
+        }
+
+        zoom = isNaN(zoom) ? 10 : Math.floor(zoom);
+        if (zoom < 0)       zoom =  0;
+        else if (zoom > 18) zoom = 18;
+
+        if (!bbox) {
+            bbox = getBBox(lat, lon, zoom, embed_width, embed_height);
+        }
+
+        // don't use QueryString.stringify here because OpenStreetMap can't
+        // cope with "," encoded as "%2C"
+        var embed_url = "http://www.openstreetmap.org/export/embed.html?bbox="+
+                         bbox.join(',')+'&layer='+layer;
+
+        var thumb_query = {
+            show:  '1',
+            fmt:   'png',
+            layer: 'mapnik', // the only layer that seems to work currently
+            lon:   lon,
+            lat:   lat,
+            z:     Math.max(0,zoom-1), // zoom out a bit for thumbnail
+            w:     thumb_width,
+            h:     thumb_height,
+            att:   'none'
+        };
+
+        if (marker) {
+            embed_url += '&marker='+marker.join(',');
+            thumb_query.mlat0 = marker[0];
+            thumb_query.mlon0 = marker[1];
+        }
+
+        return [{
+            href: embed_url,
+            rel:  CONFIG.R.reader,
+            type: CONFIG.T.text_html,
+            width:  embed_width,
+            height: embed_height
+        }, {
+            href: "http://ojw.dev.openstreetmap.org/StaticMap/?"+QueryString.stringify(thumb_query),
+            rel:  CONFIG.R.thumbnail,
+            type: CONFIG.T.image_png,
+            width:  thumb_width,
+            height: thumb_height
+        }];
     },
 
     tests: [


### PR DESCRIPTION
This parses now the new OpenStreetMap URL scheme which uses #hashes and also the URLs of embedded maps. It now also supports a single marker.
