### PR TITLE
parse new Google Maps url scheme (#!data=...)

### DIFF
--- a/plugins/domains/maps.google.com.js
+++ b/plugins/domains/maps.google.com.js
@@ -11,7 +11,7 @@ var TypeMap = {
 
 function diameterToZoom (diameter) {
     var zoom = Math.floor(19 - Math.log(diameter / 1000) / Math.LN2);
-    return zoom < 0 ? 0 : zoom;
+    return zoom < 0 ? 0 : zoom > 20 ? 20 : zoom;
 }
 
 module.exports = {


### PR DESCRIPTION
This parses the URL scheme of the new Google Maps GUI.

**Problem:** The new Google Maps lives under https://www.google.com/maps (currently https://www.google.com/maps/preview). This would be the same domain as the Google search and a different domain as the old maps. Therefore this does not actually work, because it cannot match the correct domain. How can I solve this?
