### PR TITLE
fixed isHttps test for relative protocol links. 

### DIFF
--- a/static/js/iframely.js
+++ b/static/js/iframely.js
@@ -344,7 +344,7 @@
                     .attr('allowfullscreen', true)
                     .attr('webkitallowfullscreen', true)
                     .attr('mozallowfullscreen', true);
-                    
+
 
                 if (options && options.disableSizeWrapper) {
                     return $iframe;
@@ -544,7 +544,7 @@
         }
 
         function isHttps(href) {
-            return href.indexOf('//:') == 0 || href.indexOf('https://') == 0;
+            return /^(?:https:)?\/\/.+/i.test(href);
         }
 
         var result = links && links.filter && links.filter(function(link) {


### PR DESCRIPTION
relative protocol links are constructed by leaving the http: or https: component off.  (i.e //mydomain.com/index.html)  

A regex is more accurate than an indexOf() here.  The pattern can properly match the beginning of the string - which is the only place that defines protocol http or https.
