### PR TITLE
npm test path to vows doesnt need to be explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "main": "./lib/iframely",
 
     "scripts": {
-        "test": "./node_modules/vows/bin/vows test/main.js --isolate --spec"
+        "test": "vows test/main.js --isolate --spec"
     },
 
     "engines": {


### PR DESCRIPTION
npm adds `node_modules/.bin/vows` to the path anyway ([docs](https://www.npmjs.org/doc/misc/npm-scripts.html#path)).
