### PR TITLE
Environment aware configuration

### DIFF
--- a/config.js
+++ b/config.js
@@ -148,7 +148,11 @@
         }
     };
 
-    var local_config_path = path.resolve(__dirname, "config.local.js");
+    var local_config_path = path.resolve(
+      __dirname,
+      "config." + (process.env.NODE_ENV || "local") + ".js"
+    );
+
     if (fs.existsSync(local_config_path)) {
         var local = require(local_config_path);
         _.extend(config, local);


### PR DESCRIPTION
This patch adds the ability to create environment specific configuration files.  For instance, when deploying to Heroku, you may want to use a different baseAppUrl than your development machine.

The patch relies on the `NODE_ENV` environment variable to determine the current environment.  If this is unset, it defaults to "local".
