### PR TITLE
Support for GitHub Gists to individual files within a Gist

### DIFF
--- a/plugins/domains/github.gist.js
+++ b/plugins/domains/github.gist.js
@@ -1,6 +1,6 @@
 module.exports = {
 
-    re: /^https?:\/\/gist\.github\.com\/(\w+\/)(\w+)/i,
+    re: /^https?:\/\/gist\.github\.com\/(\w+\/)(\w+)(#(\w+))?/i,
 
     mixins: [
         "og-site",
@@ -8,20 +8,28 @@ module.exports = {
         "favicon"
     ],
 
-    getMeta: function(meta) {        
+    getMeta: function(meta) {
         return (meta.og && meta.og.title) ? {
             title: meta.og.title,
             description: meta["html-title"]
         } : {
             title: meta["html-title"]
-        }
+        };
     },
 
     getLink: function(urlMatch) {
+        var scriptUrl;
+        if (urlMatch[4]) {
+            scriptUrl = 'https://gist.github.com/' + urlMatch[2] +'.js?file=' + urlMatch[4];
+        } else {
+            scriptUrl = 'https://gist.github.com/' + urlMatch[2] +'.js';
+
+        }
+
         return {
             type: CONFIG.T.text_html,
             rel: [CONFIG.R.reader, CONFIG.R.ssl],
-            html: '<script type="text/javascript" src="https://gist.github.com/' + urlMatch[2] +'.js"></script>'
+            html: '<script type="text/javascript" src="' + scriptUrl + '"></script>'
         };
     },
 
@@ -34,6 +42,7 @@ module.exports = {
         "https://gist.github.com/3054754",
         "https://gist.github.com/2719090",
         "https://gist.github.com/schisamo/163c34f3f6335bc12d45",
-        "https://gist.github.com/iparamonau/635df38fa737a1d80d23"
+        "https://gist.github.com/iparamonau/635df38fa737a1d80d23",
+        "https://gist.github.com/suprememoocow/a26a7cc168a71cc3c69b#file-script-alert-1-script"
     ]
 };


### PR DESCRIPTION
GitHub supports permalinks to individual files within a Gist, such as https://gist.github.com/suprememoocow/4e36e6f29ee07160d42c#file-harness-lua

This PR adds support to iframely so that when the hash of the embedded Gist link contains a hash, it'll attempt to show only the single file. 

