### PR TITLE
Add camo proxy image plugin

### DIFF
--- a/lib/plugins/validators/async/23_camoImage.js
+++ b/lib/plugins/validators/async/23_camoImage.js
@@ -1,0 +1,32 @@
+var crypto = require('crypto');
+var isCamoProxyEnabled = !!CONFIG.camo_proxy_key && CONFIG.camo_proxy_host;
+
+function isSSL(link) {
+  return link.rel.indexOf('ssl') > -1;
+}
+
+function isImage(link) {
+  return link.type.match(/^image/);
+}
+
+module.exports = {
+  prepareLink: function (url, link, options, cb) {
+    if (!isCamoProxyEnabled || !isImage(link) || isSSL(link)) {
+      cb();
+      return;
+    }
+
+    var hexDigest, hexEncodedPath;
+
+    hexDigest = crypto.createHmac('sha1', CONFIG.camo_proxy_key).update(link.href).digest('hex');
+    hexEncodedPath = (new Buffer(link.href)).toString('hex');
+
+    link.href = [
+      CONFIG.camo_proxy_host,
+      hexDigest,
+      hexEncodedPath
+    ].join('/');
+
+    cb();
+  }
+};


### PR DESCRIPTION
This PR enables all images to be proxied through https://github.com/atmos/camo so users can load assets more securely.

For this to work you need to set up in your config file two variables: `camo_proxy_key` and `camo_proxy_host`.