### PR TITLE
Place iframely-utils at bottom of <body> element to ensure DOM is loaded

### DIFF
--- a/views/embed-html.ejs
+++ b/views/embed-html.ejs
@@ -15,10 +15,10 @@
             position: relative;
         }
     </style>
-    <script type="text/javascript" src="<%= CONFIG.baseStaticUrl %>/js/iframely-utils.js"></script>
 <body>
     <div id='iframely-content'>
         <%- html %>
     <div>
+    <script type="text/javascript" src="<%= CONFIG.baseStaticUrl %>/js/iframely-utils.js"></script>
 </body>
 </html>


### PR DESCRIPTION
With the last version of iframely I'm getting this error in the `/render` endpoint:

![](http://i.imgur.com/zw8LcX2.png)

This commit fixes that issue.