### PR TITLE
Add optional windowId param when registering iframe

### DIFF
--- a/static/js/iframely-for-iframe.js
+++ b/static/js/iframely-for-iframe.js
@@ -80,26 +80,30 @@
 
     $.iframely.registerIframesIn = function($parent) {
 
-        $parent.find('iframe.iframely-iframe').each(function() {
-
+        $parent.find('iframe').each(function() {
             var $iframe = $(this);
+            $.iframely.registerIframe($iframe);
+        });
 
-            if ($iframe.attr('iframely-registered')) {
-                return;
-            }
+    };
 
-            $iframe.attr('iframely-registered', true);
+    $.iframely.registerIframe = function($iframe, id) {
+        if (!$iframe || $iframe.attr('iframely-registered')) {
+            return;
+        }
 
-            $iframe.load(function() {
+        $iframe.attr('iframely-registered', true);
 
-                var iframesCounter = $.iframely.iframesCounter = ($.iframely.iframesCounter || 0) + 1;
+        $iframe.load(function() {
 
-                $.iframely.iframes[iframesCounter] = $iframe;
-                windowMessaging.postMessage({
-                    method: "register",
-                    windowId: iframesCounter
-                }, '*', this.contentWindow);
-            });
+            var iframesCounter = $.iframely.iframesCounter = ($.iframely.iframesCounter || 0) + 1,
+                windowId = id || iframesCounter;
+
+            $.iframely.iframes[windowId] = $iframe;
+            windowMessaging.postMessage({
+                method: "register",
+                windowId: windowId
+            }, '*', this.contentWindow);
         });
     };
 

--- a/static/js/iframely.js
+++ b/static/js/iframely.js
@@ -110,25 +110,29 @@
     $.iframely.registerIframesIn = function($parent) {
 
         $parent.find('iframe').each(function() {
-
             var $iframe = $(this);
+            $.iframely.registerIframe($iframe);
+        });
 
-            if ($iframe.attr('iframely-registered')) {
-                return;
-            }
+    };
 
-            $iframe.attr('iframely-registered', true);
+    $.iframely.registerIframe = function($iframe, id) {
+        if (!$iframe || $iframe.attr('iframely-registered')) {
+            return;
+        }
 
-            $iframe.load(function() {
+        $iframe.attr('iframely-registered', true);
 
-                var iframesCounter = $.iframely.iframesCounter = ($.iframely.iframesCounter || 0) + 1;
+        $iframe.load(function() {
 
-                $.iframely.iframes[iframesCounter] = $iframe;
-                windowMessaging.postMessage({
-                    method: "register",
-                    windowId: iframesCounter
-                }, '*', this.contentWindow);
-            });
+            var iframesCounter = $.iframely.iframesCounter = ($.iframely.iframesCounter || 0) + 1,
+                windowId = id || iframesCounter;
+
+            $.iframely.iframes[windowId] = $iframe;
+            windowMessaging.postMessage({
+                method: "register",
+                windowId: windowId
+            }, '*', this.contentWindow);
         });
     };
 


### PR DESCRIPTION
Adding a optional param to enable specific windowIds to be added when registering an iframe.

Our use case is that we have objects that need to know when its contained iframe is going to be resized It's easier to identify if the received `resize` postMessage event concerns the object if we know the `windowId` when registering.

I recommend using the `split` view for reviewing this diff.