### PR TITLE
Add content-lenght in bytes in image metadata

### DIFF
--- a/lib/oembed.js
+++ b/lib/oembed.js
@@ -74,6 +74,7 @@ exports.getOembed = function(uri, data) {
             if (m.width && m.height) {
                 oembed.width = m.width;
                 oembed.height = m.height;
+                oembed.content_length = m.content_length;
             }
         }
 

--- a/lib/plugins/validators/async/22_imageSize.js
+++ b/lib/plugins/validators/async/22_imageSize.js
@@ -63,7 +63,8 @@ module.exports = {
                 link._imageMeta = {
                     type: data.format,
                     width: data.width,
-                    height: data.height
+                    height: data.height,
+                    content_length: data.content_length
                 };
             }
 

--- a/lib/plugins/validators/media.js
+++ b/lib/plugins/validators/media.js
@@ -71,10 +71,11 @@ function moveMediaAttrs(link) {
 
         var _imageMeta = link._imageMeta;
 
-        if (_imageMeta && _imageMeta.width && _imageMeta.height && _imageMeta.type && !link._imageMeta.error) {
+        if (_imageMeta && _imageMeta.width && _imageMeta.height && _imageMeta.type && _imageMeta.content_length && !link._imageMeta.error) {
             m.width = link._imageMeta.width;
             m.height = link._imageMeta.height;
-            link.type = "image/" + link._imageMeta.type.toLowerCase()
+            m.content_length = link._imageMeta.content_length;
+            link.type = "image/" + link._imageMeta.type.toLowerCase();
         }
 
         if (!isEmpty(m)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -184,7 +184,7 @@ exports.getImageMetadata = function(uri, options, callback){
 
     cache.withCache("image-meta:" + uri, function(callback) {
 
-        var loadImageHead, imageResponseStarted, totalTime, timeout;
+        var loadImageHead, imageResponseStarted, totalTime, timeout, contentLength;
         var requestInstance = null;
 
         function finish(error, data) {
@@ -269,6 +269,7 @@ exports.getImageMetadata = function(uri, options, callback){
                             if (options.debug) {
                                 imageResponseStarted = totalTime();
                             }
+                            contentLength = parseInt(res.headers['content-length'] || '0', 10);
                             imagesize(res, cb);
                         } else {
                             cb(res.statusCode);
@@ -283,6 +284,8 @@ exports.getImageMetadata = function(uri, options, callback){
                 if (options.debug) {
                     loadImageHead = createTimer();
                 }
+
+                data.content_length = contentLength;
 
                 cb(null, data);
             }

--- a/test/main.js
+++ b/test/main.js
@@ -97,6 +97,7 @@ vows.describe('Tests')
             'has correct size and type': function(error, data) {
                 assert.equal(data.width, 400);
                 assert.equal(data.height, 211);
+                assert.equal(data.content_length, 33572);
                 assert.equal(data.format, "jpeg");
             }
         }


### PR DESCRIPTION
Adding content-length in bytes for images, useful for showing image size in human format. :ok_hand: 

![](http://i.imgur.com/he7zUjx.png)