### PR TITLE
Datawrapper.de use an other domain

### DIFF
--- a/plugins/domains/datawrapper.de.js
+++ b/plugins/domains/datawrapper.de.js
@@ -1,6 +1,6 @@
 module.exports = {
     re: [
-        /^http[s]?:\/\/cf.datawrapper.de\/(.+?)(?:[\/](?:index\.html)?)?$/
+        /^http[s]?:\/\/(cf.datawrapper.de|datawrapper.dwcdn.net)\/(.+?)(?:[\/](?:index\.html)?)?$/
     ],
 
     mixins: [
@@ -11,7 +11,7 @@ module.exports = {
         return {
             type: CONFIG.T.text_html,
             rel: [CONFIG.R.app, CONFIG.R.ssl, CONFIG.R.html5],
-            href: "http://cf.datawrapper.de/" + urlMatch[1] + "/?for=iframely",
+            href: urlMatch[0] + "?for=iframely",
             height: 350
         }
     },
@@ -23,6 +23,7 @@ module.exports = {
     },
 
     tests: [
+        "http://datawrapper.dwcdn.net/zjCKi/2/",
         "http://cf.datawrapper.de/zjCKi/2/",
         "http://cf.datawrapper.de/Gx44C/21/",
         "http://cf.datawrapper.de/RrO5t/2/"


### PR DESCRIPTION
They use an other domain when you want to share your chart.

![](http://i.imgur.com/sNtBZRb.png)

I just hope they'll soon handle their own oembed plugin ...