### PR TITLE
[config] add setting to group links by rel

### DIFF
--- a/config.local.js.SAMPLE
+++ b/config.local.js.SAMPLE
@@ -8,6 +8,13 @@
         baseAppUrl: "http://yourdomain.com",
         relativeStaticUrl: "/r",
 
+        // For legacy reasons the response format of Iframely open-source is
+        // different by default as it does not group the links array by rel.
+        // In order to get the same grouped ressonse as in Cloud API,
+        // add `&group=true` to your request to change response per request
+        // or set `groupLinks` in your config to `true` for a global change.
+        GROUP_LINKS: false,
+
         SKIP_OEMBED_RE_LIST: [
             // /^https?:\/\/yourdomain\.com\//,
         ],

--- a/modules/api/views.js
+++ b/modules/api/views.js
@@ -136,7 +136,7 @@ module.exports = function(app) {
                 autoplayMode: getBooleanParam(req, 'autoplay')
             });
 
-            if (req.query.group) {
+            if (req.query.group || CONFIG.GROUP_LINKS) {
                 var links = result.links;
                 var groups = {};
                 CONFIG.REL_GROUPS.forEach(function(rel) {


### PR DESCRIPTION
Add `GROUP_LINKS` setting to `config.local.js.SAMPLE` to be able to set the grouped response format of the Cloud API globally rather than per request with the query parameter. The new setting defaults to `false`