### PR TITLE
[general] fix missing spaces from line-break replacements

### DIFF
--- a/lib/plugins/system/meta/HTMLMetaHandler.js
+++ b/lib/plugins/system/meta/HTMLMetaHandler.js
@@ -61,7 +61,7 @@ HTMLMetaHandler.prototype.onopentag = function(name, attributes) {
 
             if (typeof(value) === 'string') {
                 // Remove new lines.
-                value = value.replace(/(\r\n|\n|\r)/gm,"");
+                value = value.replace(/(\r\n|\n|\r)/gm, ' ');
                 // Trim.
                 value = value.replace(/^\s+|\s+$/g, '');
             }


### PR DESCRIPTION
In meta-content descriptions when there were line-breaks they were just removed. By that there was a space missing between the joined lines. `1.\n2` would become `1.2` instead of `1. 2`. Fixed by replacing line-breaks with a space rather than removing them.