### PR TITLE
Add content-length for non-html resources

### DIFF
--- a/lib/plugins/system/htmlparser/htmlparser.js
+++ b/lib/plugins/system/htmlparser/htmlparser.js
@@ -50,7 +50,7 @@ module.exports = {
                     return cb(null, {
                         nonHtmlContentData: {
                             type: resp.headers['content-type'],
-                            length: resp.headers['content-length']
+                            content_length: resp.headers['content-length']
                         }
                     });
                 }
@@ -86,7 +86,7 @@ module.exports = {
         return {
             href: url,
             type: nonHtmlContentType,
-            length: parseInt(nonHtmlContentLength, 10),
+            content_length: parseInt(nonHtmlContentLength, 10),
             rel: CONFIG.R.file
             // client-side iframely.js will also properly render video/mp4 and image files this way
         };

--- a/lib/plugins/system/htmlparser/htmlparser.js
+++ b/lib/plugins/system/htmlparser/htmlparser.js
@@ -48,7 +48,10 @@ module.exports = {
 
                 if('content-type' in resp.headers && !/text\/html|application\/xhtml\+xml/gi.test(resp.headers['content-type'])){
                     return cb(null, {
-                        nonHtmlContentType: resp.headers['content-type']
+                        nonHtmlContentData: {
+                            type: resp.headers['content-type'],
+                            length: resp.headers['content-length']
+                        }
                     });
                 }
 
@@ -70,7 +73,9 @@ module.exports = {
             });
     },
 
-    getLink: function(url, nonHtmlContentType) {
+    getLink: function(url, nonHtmlContentData) {
+        var nonHtmlContentType = nonHtmlContentData.type;
+        var nonHtmlContentLength = nonHtmlContentData.length;
 
         // HEADS UP: do not ever remove the below check for 'javascript' or 'flash' in content type
         // if left allowed, it'll make apps vulnerable for XSS attacks as such files will be rendered as regular embeds
@@ -81,6 +86,7 @@ module.exports = {
         return {
             href: url,
             type: nonHtmlContentType,
+            length: parseInt(nonHtmlContentLength, 10),
             rel: CONFIG.R.file
             // client-side iframely.js will also properly render video/mp4 and image files this way
         };


### PR DESCRIPTION
If a resource URL is not HTML the content-length / filesize is added to the response.