### PR TITLE
Added custom ttl for 4xx responses

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -349,7 +349,7 @@
                         value = 'Requested page error: ' + error;
                     }
 
-                    setResponseToCache(error, 'text/html', req, res, value);
+                    setResponseToCache(error, 'text/html', req, res, value, CONFIG.CACHE_TTL_PAGE_404);
 
                 } else if (typeof error === "string" && error.match(/^timeout/)) {
 


### PR DESCRIPTION
There are custom TTL for timeout errors and custom TTL for 4xx statuses in the config, but only the first one is passed and really used. This PR fixes that, so 4xx statuses are not cached as normal responses