### PR TITLE
Fix error handling in core.js #runMethods()

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -255,8 +255,9 @@
                     if (error) {
 
                         if (error.code) {
+                            var statusCode = error.code;
                             error = {};
-                            error[SYS_ERRORS.responseStatusCode] = error.code;
+                            error[SYS_ERRORS.responseStatusCode] = statusCode;
                         }
 
                         if (error instanceof Error) {


### PR DESCRIPTION
`error.responseStatusCode` was always set back to `undefined` because `error` itself was reset to an empty object.