### PR TITLE
[config] add option to set the maximum number of redirects

### DIFF
--- a/config.local.js.SAMPLE
+++ b/config.local.js.SAMPLE
@@ -15,6 +15,10 @@
         // or set `groupLinks` in your config to `true` for a global change.
         GROUP_LINKS: false,
 
+        // Number of maximum redirects to follow before aborting the page
+        // request with `redirect loop` error.
+        MAX_REDIRECTS: 4,
+
         SKIP_OEMBED_RE_LIST: [
             // /^https?:\/\/yourdomain\.com\//,
         ],

--- a/lib/core.js
+++ b/lib/core.js
@@ -1053,7 +1053,7 @@
             options.jar = request.jar();
         }
 
-        if (options.redirectsCount && options.redirectsCount > 4) {
+        if (options.redirectsCount && options.redirectsCount > (CONFIG.MAX_REDIRECTS || 4)) {
             return cb('redirect loop');
         }
 


### PR DESCRIPTION
Add `MAX_REDIRECTS` setting to `config.local.js.SAMPLE` to be able to set the maximum redirects iframely follows before aborting with the "redirect loop" error.

If the `CONFIG.MAX_REDIRECTS` is `undefined` it defaults to `4` in the redirect loop check.