### PR TITLE
[meta] add fallback description retrieval from ptag

### DIFF
--- a/plugins/meta/description-from-p-tag.js
+++ b/plugins/meta/description-from-p-tag.js
@@ -1,0 +1,28 @@
+var decodeHTML5 = require('entities').decodeHTML5;
+var utils = require('../../lib/utils');
+var getCharset = utils.getCharset;
+var encodeText = utils.encodeText;
+
+module.exports = {
+
+    getMeta: function(cheerio, meta) {
+        // Get the text from the first <p> tag that's not in a header
+        var description;
+        cheerio("body p").each(function() {
+            var $p = cheerio(this);
+
+            if (!$p.parents("noscript, header,#header,[role='banner']").length) {
+                description = decodeHTML5(encodeText(meta.charset, cheerio(this).text()));
+                return false;
+            }
+        });
+
+        if (description) {
+            return {
+                description: description
+            }
+        }
+    },
+
+    lowestPriority: true
+};


### PR DESCRIPTION
Quite some sites on the web don't provide a proper description via meta tags and/or og. For those sites, we can fall back to extract the text from the first paragraph. This commit/pr adds adding a plugin for doing exactly this. 

Example URLs to test with:

https://kremlin.ru (I used this to validate we get the decoding right)
https://blog.hipchat.com/2012/07/04/mentions-and-names-take-2/