### PR TITLE
[domains] twitter.status - fix regex replace for multiline html-titles

### DIFF
--- a/plugins/domains/twitter.status.js
+++ b/plugins/domains/twitter.status.js
@@ -50,7 +50,7 @@ module.exports = {
 
             var oembed = JSON.parse(data);
 
-            oembed.title = meta['html-title'].replace(/on Twitter:.*?$/, "on Twitter");
+            oembed.title = meta['html-title'].replace(/on Twitter:(?:.|\s)+/m, "on Twitter");
 
             cb(null, {
                 title: oembed.title,


### PR DESCRIPTION
This is a fix for the changed `title` generation from https://github.com/itteco/iframely/pull/94.
Fixes regex to correctly set the `title` from a multiline `html-title`.