### PR TITLE
Support custom priority for plugins - for absolute ordering and overrides.

### DIFF
--- a/lib/loader/pluginLoader.js
+++ b/lib/loader/pluginLoader.js
@@ -29,6 +29,13 @@
         postPluginsList = pluginLoader._postPluginsList = [],
         pluginsByDomain = {};
 
+
+    var messageTemplates = {
+        IGNORE_DUPLICATE_PRIORITY_PLUGIN: _.template("Ignoring duplicate priority plugin: <%= currentPluginPath %>, keeping: <%= existingPluginPath %>"),
+        IGNORE_LOWER_PRIORITY_PLUGIN: _.template("Ignoring lower priority plugin: <%= currentPluginPath %>, keeping: <%= existingPluginPath %>"),
+        OVERRIDE_LOWER_PRIORITY_PLUGIN: _.template("Overriding existing lower priority plugin: <%= existingPluginPath %> with new: <%= currentPluginPath %>")
+    }
+
     /*
      * ===================
      * Loading plugins
@@ -174,7 +181,7 @@
             }
 
             // Check post plugin.
-            // TODO: only prapereLink method abailable.
+            // TODO: only prapereLink method available.
             // TODO: exclude prapereLink method from other plugins.
             pluginDeclaration.post = bits.indexOf('validators') > -1;
             if (pluginDeclaration.post) {
@@ -186,9 +193,29 @@
 
             // ID.
             pluginDeclaration.id = getFileName(bits[bits.length - 1]).toLowerCase();
+            pluginDeclaration.pluginPath = pluginPath;
+
+            if (!plugin.priority) {
+                if (plugin.highestPriority) {
+                    plugin.priority = 2;
+                } else if (!_.isUndefined(plugin.lowestPriority)) {
+                    plugin.priority = 0;
+                } else {
+                    plugin.priority = 1;
+                }
+            }
+
             if (pluginDeclaration.id in plugins) {
-                console.error("Duplicate plugin id (filename)", pluginPath);
-                return;
+                var messageArg = {currentPluginPath: pluginPath, existingPluginPath: plugins[pluginDeclaration.id].pluginPath};
+                if (plugin.priority === plugins[pluginDeclaration.id].module.priority) {
+                    console.warn(messageTemplates.IGNORE_DUPLICATE_PRIORITY_PLUGIN(messageArg));
+                    return;
+                } else if (pluginDeclaration.priority < plugins[pluginDeclaration.id].module.priority) {
+                    console.warn(messageTemplates.IGNORE_LOWER_PRIORITY_PLUGIN(messageArg));
+                    return;
+                } else {
+                    console.log(messageTemplates.OVERRIDE_LOWER_PRIORITY_PLUGIN(messageArg));
+                }
             }
 
             // Normalize RE.
@@ -465,6 +492,13 @@
                 if (p.module.highestPriority) {
                     return 2;
                 }
+
+                // custom priority
+                if (p.module.priority) {
+                    return p.module.priority;
+                }
+
+                // default priority
                 return 1;
             }
 


### PR DESCRIPTION
1) Custom priority for plugins - other than having lowestPriority and highestPriority, this commit supports custom "priority" for absolute ordering of modules.

2) Allows duplicate plugin-id with overriding of lower priority one by higher one - earlier duplicate one was getting ignored.

Justification --
Many of the domain plugins mention "og-site" as mixin. I wanted to override how "site" value is generated - that is I did not want to use twitter user as site. To achieve that without this commit changes would have required duplicating such domain plugins and then using another custom site meta plugin rather than og-site. But this change, I only need to declare a new og-site plugin and give it a higher priority.

Please let me know if more justifications are needed.