### PR TITLE
Add Dockerfile and an init script for container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:5.8
+
+EXPOSE 8061
+
+COPY . /iframely
+
+WORKDIR /iframely
+
+RUN DEPS="libkrb5-dev" \
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends $DEPS && \
+    npm install -g forever && \
+    npm install && \
+    apt-get purge -y --auto-remove $DEPS && \
+    apt-get autoremove && \
+    apt-get clean
+
+ENTRYPOINT ["/iframely/docker/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+export ARGV="$@"
+export ARGC="$#"
+
+function sigterm_handler() {
+    echo "SIGTERM signal received."
+    forever stopall
+}
+
+trap "sigterm_handler; exit" TERM
+
+function entrypoint() {
+    if [ "$ARGC" -eq 0 ]
+    then
+        # Run server in cluster mode by default
+        forever start cluster.js
+    else
+        # Use command line arguments supplied at runtime
+        forever start $ARGV
+    fi
+
+    forever --fifo logs 0 &
+    wait
+}
+
+entrypoint


### PR DESCRIPTION
The Docker container will:
  - Run `forever start cluster.js` by default
  - Run `forever start <args>` if command line arguments are supplied
  - Gracefully shutdown when receiving SIGTERM from `docker stop`

A brief documentation:

```bash
docker build -t iframely:latest .
docker run -it -p 8061:8061 -v $PWD/config.local.js:/iframely/config.local.js --name iframely iframely:latest
docker stop iframely
```

Signed-off-by: kfei <kfei@kfei.net>