### PR TITLE
JSON formatted error responses and end to end tests

### DIFF
--- a/config.test.js
+++ b/config.test.js
@@ -1,0 +1,17 @@
+(function() {
+
+  var config = {
+
+    DEBUG: true,
+    RICH_LOG_ENABLED: true,
+
+    baseAppUrl: "https://localhost",
+    port: 8080,
+
+    RESPONSE_TIMEOUT: 1 * 100, //ms
+
+    BLACKLIST_DOMAINS_RE: /blacklisted.*/
+  };
+
+  module.exports = config;
+})();

--- a/package.json
+++ b/package.json
@@ -52,7 +52,11 @@
     "devDependencies": {
         "vows":         "~0.7.0",
         "feedparser":   "0.16",
-        "mongoose":     "4.0.3"
+        "mongoose":     "4.0.3",
+        "chai": "^3.5.0",
+        "mocha": "^3.1.2",
+        "mock-http-server": "0.0.4",
+        "supertest": "^2.0.0"
     },
 
     "iframely-proxy-plugins": true,
@@ -60,7 +64,8 @@
     "main": "./lib/core",
 
     "scripts": {
-        "test": "vows test/main.js --isolate --spec"
+        "test": "vows test/main.js --isolate --spec && npm run test-e2e",
+        "test-e2e": "NODE_ENV=test PORT=8080 mocha test"
     },
 
     "engines": {

--- a/server.js
+++ b/server.js
@@ -92,7 +92,7 @@ function errorHandler(err, req, res, next) {
             respondWithError(res, 403, 'Forbidden');
         }
         else if (code === 410) {
-            respondWithError(res, 410, 'Blacklisted');
+            respondWithError(res, 410, 'Gone');
         }
         else {
             respondWithError(res, code, 'Server error');

--- a/server.js
+++ b/server.js
@@ -59,17 +59,23 @@ function logErrors(err, req, res, next) {
 
 var errors = [401, 403, 408];
 
+function respondWithError (res, code, msg) {
+    var err = {
+        error: {
+            source: 'iframely',
+            code: code,
+            message: msg
+        }
+    };
+    res.statusCode = code;
+    res.json(err);
+}
+
 function errorHandler(err, req, res, next) {
-
     if (err instanceof NotFound) {
-
-        res.writeHead(404);
-        res.end(err.message);
-
+        respondWithError(res, 404, err.message);
     } else {
-
         var code = err.code || 500;
-
         errors.map(function(e) {
             if (err.message.indexOf(e) > - 1) {
                 code = e;
@@ -77,11 +83,20 @@ function errorHandler(err, req, res, next) {
         });
 
         if (err.message.indexOf('timeout') > -1) {
-            code = 408;
+            respondWithError(res, 408, 'Timeout');
         }
-
-        res.writeHead(code);
-        res.end(err.message);
+        else if (code === 401) {
+            respondWithError(res, 401, 'Unauthorized');
+        }
+        else if (code === 403) {
+            respondWithError(res, 403, 'Forbidden');
+        }
+        else if (code === 410) {
+            respondWithError(res, 410, 'Blacklisted');
+        }
+        else {
+            respondWithError(res, code, 'Server error');
+        }
     }
 }
 

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -1,16 +1,18 @@
 'use strict';
 
-const request = require('supertest');
-const ServerMock = require("mock-http-server");
-const chai = require('chai');
+var request = require('supertest');
+var ServerMock = require('mock-http-server');
+var chai = require('chai');
 
-describe('meta endpoint', () => {
+describe('meta endpoint', function() {
 
-  const BASE_IFRAMELY_SERVER_URL = `http://localhost:${process.env.PORT}`;
-  const server = require('../server'); // start card meta
+  var BASE_IFRAMELY_SERVER_URL = 'http://localhost:' + process.env.PORT;
+  var server = require('../server'); // start card meta
 
-  const TARGET_MOCKED_SERVER_PORT = 9000;
-  const targetMockedServer = new ServerMock({ host: "localhost", port: TARGET_MOCKED_SERVER_PORT });
+  var TARGET_MOCKED_SERVER_PORT = 9000;
+  var TARGET_MOCKED_SERVER_BASEURL = 'http://127.0.0.1:' + TARGET_MOCKED_SERVER_PORT;
+
+  var targetMockedServer = new ServerMock({ host: 'localhost', port: TARGET_MOCKED_SERVER_PORT });
 
   beforeEach(function(done) {
     targetMockedServer.start(done);
@@ -20,27 +22,27 @@ describe('meta endpoint', () => {
     targetMockedServer.stop(done);
   });
 
-  it('should return a valid response for a valid url', done => {
+  it('should return a valid response for a valid url', function(done) {
     targetMockedServer.on({
       method: 'GET',
       path: '/testok',
       reply: {
         status:  200,
-        headers: { "content-type": "text/html" },
+        headers: { 'content-type': 'text/html' },
         body: "<html><body>Hi there!</body></html>"
       }
     });
 
-    const url = `http://127.0.0.1:${TARGET_MOCKED_SERVER_PORT}/testok`;
+    var url = TARGET_MOCKED_SERVER_BASEURL + '/testok';
     request(BASE_IFRAMELY_SERVER_URL)
-        .get(`/iframely?url=${url}`)
+        .get('/iframely?url=' + url)
         .end(function(err, res) {
           chai.expect(res.body.meta).to.exist;
           done(err);
         });
   });
 
-  it('should handle 404 responses in target urls', done => {
+  it('should handle 404 responses in target urls', function(done) {
     targetMockedServer.on({
       method: 'GET',
       path: '/test404',
@@ -49,9 +51,9 @@ describe('meta endpoint', () => {
       }
     });
 
-    const url = `http://127.0.0.1:${TARGET_MOCKED_SERVER_PORT}/test404`;
+    var url = TARGET_MOCKED_SERVER_BASEURL + '/test404';
     request(BASE_IFRAMELY_SERVER_URL)
-        .get(`/iframely?url=${url}`)
+        .get('/iframely?url=' + url)
         .end(function(err, res) {
           chai.expect(res.statusCode).to.equal(404);
           chai.expect(res.body).to.deep.equal({
@@ -65,7 +67,7 @@ describe('meta endpoint', () => {
         });
   });
 
-  it('should handle 500 responses in target urls', done => {
+  it('should handle 500 responses in target urls', function(done) {
     targetMockedServer.on({
       method: 'GET',
       path: '/test500',
@@ -74,9 +76,9 @@ describe('meta endpoint', () => {
       }
     });
 
-    const url = `http://127.0.0.1:${TARGET_MOCKED_SERVER_PORT}/test500`;
+    var url = TARGET_MOCKED_SERVER_BASEURL + '/test500';
     request(BASE_IFRAMELY_SERVER_URL)
-        .get(`/iframely?url=${url}`)
+        .get('/iframely?url=' + url)
         .end(function(err, res) {
           chai.expect(res.statusCode).to.equal(500);
           chai.expect(res.body).to.deep.equal({
@@ -90,7 +92,7 @@ describe('meta endpoint', () => {
         });
   });
 
-  it('should handle 401 responses from target servers', done => {
+  it('should handle 401 responses from target servers', function(done) {
     targetMockedServer.on({
       method: 'GET',
       path: '/test401',
@@ -99,9 +101,9 @@ describe('meta endpoint', () => {
       }
     });
 
-    const url = `http://127.0.0.1:${TARGET_MOCKED_SERVER_PORT}/test401`;
+    var url = TARGET_MOCKED_SERVER_BASEURL + '/test401';
     request(BASE_IFRAMELY_SERVER_URL)
-        .get(`/iframely?url=${url}`)
+        .get('/iframely?url=' + url)
         .end(function(err, res) {
           chai.expect(res.statusCode).to.equal(401);
           chai.expect(res.body).to.deep.equal({
@@ -115,7 +117,7 @@ describe('meta endpoint', () => {
         });
   });
 
-  it('should handle 403 responses from target servers', done => {
+  it('should handle 403 responses from target servers', function(done) {
     targetMockedServer.on({
       method: 'GET',
       path: '/test403',
@@ -124,9 +126,9 @@ describe('meta endpoint', () => {
       }
     });
 
-    const url = `http://127.0.0.1:${TARGET_MOCKED_SERVER_PORT}/test403`;
+    var url = TARGET_MOCKED_SERVER_BASEURL + '/test403';
     request(BASE_IFRAMELY_SERVER_URL)
-        .get(`/iframely?url=${url}`)
+        .get('/iframely?url=' + url)
         .end(function(err, res) {
           chai.expect(res.statusCode).to.equal(403);
           chai.expect(res.body).to.deep.equal({
@@ -153,9 +155,9 @@ describe('meta endpoint', () => {
       }
     });
 
-    const url = `http://127.0.0.1:${TARGET_MOCKED_SERVER_PORT}/test-timeout`;
+    var url = TARGET_MOCKED_SERVER_BASEURL + '/test-timeout';
     request(BASE_IFRAMELY_SERVER_URL)
-        .get(`/iframely?url=${url}`)
+        .get('/iframely?url=' + url)
         .end(function(err, res) {
           chai.expect(res.statusCode).to.equal(408);
           chai.expect(res.body).to.deep.equal({
@@ -175,14 +177,14 @@ describe('meta endpoint', () => {
       path: '/test-timeout',
       reply: {
         status:  200,
-        headers: { "content-type": "text/html" },
+        headers: { 'content-type': 'text/html' },
         body: "<html><body>Hi there!</body></html>"
       }
     });
 
-    const url = `http://blacklisted.com/test-timeout`;
+    var url = 'http://blacklisted.com/test-timeout';
     request(BASE_IFRAMELY_SERVER_URL)
-        .get(`/iframely?url=${url}`)
+        .get('/iframely?url=' + url)
         .end(function(err, res) {
           chai.expect(res.statusCode).to.equal(410);
           chai.expect(res.body).to.deep.equal({

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -1,0 +1,199 @@
+'use strict';
+
+const request = require('supertest');
+const ServerMock = require("mock-http-server");
+const chai = require('chai');
+
+describe('meta endpoint', () => {
+
+  const BASE_IFRAMELY_SERVER_URL = `http://localhost:${process.env.PORT}`;
+  const server = require('../server'); // start card meta
+
+  const TARGET_MOCKED_SERVER_PORT = 9000;
+  const targetMockedServer = new ServerMock({ host: "localhost", port: TARGET_MOCKED_SERVER_PORT });
+
+  beforeEach(function(done) {
+    targetMockedServer.start(done);
+  });
+
+  afterEach(function(done) {
+    targetMockedServer.stop(done);
+  });
+
+  it('should return a valid response for a valid url', done => {
+    targetMockedServer.on({
+      method: 'GET',
+      path: '/testok',
+      reply: {
+        status:  200,
+        headers: { "content-type": "text/html" },
+        body: "<html><body>Hi there!</body></html>"
+      }
+    });
+
+    const url = `http://127.0.0.1:${TARGET_MOCKED_SERVER_PORT}/testok`;
+    request(BASE_IFRAMELY_SERVER_URL)
+        .get(`/iframely?url=${url}`)
+        .end(function(err, res) {
+          chai.expect(res.body.meta).to.exist;
+          done(err);
+        });
+  });
+
+  it('should handle 404 responses in target urls', done => {
+    targetMockedServer.on({
+      method: 'GET',
+      path: '/test404',
+      reply: {
+        status:  404
+      }
+    });
+
+    const url = `http://127.0.0.1:${TARGET_MOCKED_SERVER_PORT}/test404`;
+    request(BASE_IFRAMELY_SERVER_URL)
+        .get(`/iframely?url=${url}`)
+        .end(function(err, res) {
+          chai.expect(res.statusCode).to.equal(404);
+          chai.expect(res.body).to.deep.equal({
+            error: {
+              source: 'iframely',
+              code: 404,
+              message: 'Page not found'
+            }
+          });
+          done(err);
+        });
+  });
+
+  it('should handle 500 responses in target urls', done => {
+    targetMockedServer.on({
+      method: 'GET',
+      path: '/test500',
+      reply: {
+        status: 500
+      }
+    });
+
+    const url = `http://127.0.0.1:${TARGET_MOCKED_SERVER_PORT}/test500`;
+    request(BASE_IFRAMELY_SERVER_URL)
+        .get(`/iframely?url=${url}`)
+        .end(function(err, res) {
+          chai.expect(res.statusCode).to.equal(500);
+          chai.expect(res.body).to.deep.equal({
+            error: {
+              source: 'iframely',
+              code: 500,
+              message: 'Server error'
+            }
+          });
+          done(err);
+        });
+  });
+
+  it('should handle 401 responses from target servers', done => {
+    targetMockedServer.on({
+      method: 'GET',
+      path: '/test401',
+      reply: {
+        status: 401
+      }
+    });
+
+    const url = `http://127.0.0.1:${TARGET_MOCKED_SERVER_PORT}/test401`;
+    request(BASE_IFRAMELY_SERVER_URL)
+        .get(`/iframely?url=${url}`)
+        .end(function(err, res) {
+          chai.expect(res.statusCode).to.equal(401);
+          chai.expect(res.body).to.deep.equal({
+            error: {
+              source: 'iframely',
+              code: 401,
+              message: 'Unauthorized'
+            }
+          });
+          done(err);
+        });
+  });
+
+  it('should handle 403 responses from target servers', done => {
+    targetMockedServer.on({
+      method: 'GET',
+      path: '/test403',
+      reply: {
+        status: 403
+      }
+    });
+
+    const url = `http://127.0.0.1:${TARGET_MOCKED_SERVER_PORT}/test403`;
+    request(BASE_IFRAMELY_SERVER_URL)
+        .get(`/iframely?url=${url}`)
+        .end(function(err, res) {
+          chai.expect(res.statusCode).to.equal(403);
+          chai.expect(res.body).to.deep.equal({
+            error: {
+              source: 'iframely',
+              code: 403,
+              message: 'Forbidden'
+            }
+          });
+          done(err);
+        });
+  });
+
+  it('should handle timeouts from target servers', function(done) {
+    targetMockedServer.on({
+      method: 'GET',
+      path: '/test-timeout',
+      reply: {
+        body: function(req, reply) {
+          setTimeout(function(){
+            reply('ok');
+          }, 1000); // higher than RESPONSE_TIMEOUT defined in config.test.js, so request will timeout
+        }
+      }
+    });
+
+    const url = `http://127.0.0.1:${TARGET_MOCKED_SERVER_PORT}/test-timeout`;
+    request(BASE_IFRAMELY_SERVER_URL)
+        .get(`/iframely?url=${url}`)
+        .end(function(err, res) {
+          chai.expect(res.statusCode).to.equal(408);
+          chai.expect(res.body).to.deep.equal({
+            error: {
+              source: 'iframely',
+              code: 408,
+              message: 'Timeout'
+            }
+          });
+          done(err);
+        });
+  });
+
+  it('should handle blacklisted domains', function(done) {
+    targetMockedServer.on({
+      method: 'GET',
+      path: '/test-timeout',
+      reply: {
+        status:  200,
+        headers: { "content-type": "text/html" },
+        body: "<html><body>Hi there!</body></html>"
+      }
+    });
+
+    const url = `http://blacklisted.com/test-timeout`;
+    request(BASE_IFRAMELY_SERVER_URL)
+        .get(`/iframely?url=${url}`)
+        .end(function(err, res) {
+          chai.expect(res.statusCode).to.equal(410);
+          chai.expect(res.body).to.deep.equal({
+            error: {
+              source: 'iframely',
+              code: 410,
+              message: 'Blacklisted'
+            }
+          });
+          done(err);
+        });
+  });
+
+});

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -191,7 +191,7 @@ describe('meta endpoint', function() {
             error: {
               source: 'iframely',
               code: 410,
-              message: 'Blacklisted'
+              message: 'Gone'
             }
           });
           done(err);


### PR DESCRIPTION
By wrapping errors in JSON responses, it is feasible to add custom data (like error source) to the response, and upstream services can easily determine whenever are the calls to the preview url and not calls to the iframely server (or any other proxy/service in the middle) the ones failing.

This is pretty helpful in iframely cloud, but it is not available in the open source version yet.

Happy to hear suggestions about the response object signature.

Running the e2e tests requires a version of node that supports ES2015 features, though the modifications introduced in the server don't.
