### PR TITLE
Security - Load whitelist over HTTPS by default.

### DIFF
--- a/config.js
+++ b/config.js
@@ -11,11 +11,11 @@
 
     var config = {
 
-        WHITELIST_URL: 'http://iframely.com/qa/whitelist.json',
+        WHITELIST_URL: 'https://iframely.com/qa/whitelist.json',
         WHITELIST_URL_RELOAD_PERIOD: 60 * 60 * 1000,  // will reload WL every hour, if no local files are found in /whitelist folder
 
         WHITELIST_WILDCARD: {},
-        WHITELIST_LOG_URL: 'http://iframely.com/whitelist-log',
+        WHITELIST_LOG_URL: 'https://iframely.com/whitelist-log',
 
         // Default cache engine to prevent warning.
         CACHE_ENGINE: 'node-cache',

--- a/config.local.js.SAMPLE
+++ b/config.local.js.SAMPLE
@@ -172,7 +172,7 @@
                 get_params: "?rel=0&showinfo=1"     // https://developers.google.com/youtube/player_parameters
             },
             vimeo: {
-                get_params: "?byline=0&badge=0"     // http://developer.vimeo.com/player/embedding
+                get_params: "?byline=0&badge=0"     // https://developer.vimeo.com/player/embedding
             },
 
             /*

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ var sysUtils = require('./utils');
 var app = require('./app');
 
 var server = app.listen(process.env.PORT || CONFIG.port, process.env.HOST || CONFIG.host, function(){
-    console.log('\niframely is listening on ' + server.address().address + ':' + server.address().port + '\n');
+    console.log('\niframely is running on http://' + server.address().address + ':' + server.address().port + '/debug\n');
 });
 
 if (CONFIG.ssl) {


### PR DESCRIPTION
For own deployment of iframely, the whitelist is currently downloaded over unsecure HTTP. Using HTTPS can prevent multiple malicious exploits.

This PR also change the console output to give the running URL, and make it clickable (at least on iTerm).


```
$ node server
Using cache engine: node-cache
No local whitelist file detected...
-- [17-03-01 19:59:17] Loading whitelist from https://iframely.com/qa/whitelist.json
Iframely plugins loaded:
   - custom domains: 228
   - generic & meta: 94

Starting Iframely...
Base URL for embeds that require hosted renders: http://yourdomain.com

 - support@iframely.com - if you need help
 - twitter.com/iframely - news & updates
 - github.com/itteco/iframely - star & contribute

iframely is running on http://127.0.0.1:8061/debug

-- [17-03-01 19:59:28] Whitelist activated. Domains, including blacklisted: 1885
```