### PR TITLE
domains: decode Google Docs links

### DIFF
--- a/plugins/domains/google.com/docs.google.com.js
+++ b/plugins/domains/google.com/docs.google.com.js
@@ -1,9 +1,11 @@
+var decodeHTML5 = require('entities').decodeHTML5;
+
 module.exports = {
 
     provides: "schemaFileObject",
 
     re: [
-        /https:\/\/(?:docs|drive)\.google\.com\/(?:a\/[a-zA-Z0-9\-\_\.]+\/)?(forms|document|presentation|spreadsheets|file)\/d\/([a-zA-Z0-9_-]+)/i        
+        /https:\/\/(?:docs|drive)\.google\.com\/(?:a\/[a-zA-Z0-9\-\_\.]+\/)?(forms|document|presentation|spreadsheets|file)\/d\/([a-zA-Z0-9_-]+)/i
     ],
 
     mixins: [
@@ -35,12 +37,12 @@ module.exports = {
             var file = {
                 rel: [CONFIG.R.file, CONFIG.R.html5],
                 href: schemaFileObject.embedURL || schemaFileObject.embedUrl,
-                type: CONFIG.T.text_html 
-            };            
+                type: CONFIG.T.text_html
+            };
 
             if (schemaFileObject.playerType) {
 
-                // HEADS UP: 
+                // HEADS UP:
                 // There is a problem with player as embedURL: x-frame-options is SAMEORIGIN
                 file.href = "https://drive.google.com/file/d/" + urlMatch[2] + "/preview";
                 file.rel.push(CONFIG.R.player);
@@ -49,7 +51,7 @@ module.exports = {
             } else if (urlMatch[1] === "forms" || urlMatch[1] === "document" || urlMatch[1] === "file") {
                 file["aspect-ratio"] = 1 / Math.sqrt(2); // A4 portrait
                 // "App" to prevent Google Forms be presented as Player through Twitter-player mixin as Player prevails on Readers
-                file.rel.push (urlMatch[1] === "forms" ? CONFIG.R.app : CONFIG.R.reader); 
+                file.rel.push (urlMatch[1] === "forms" ? CONFIG.R.app : CONFIG.R.reader);
 
             /// } else if (urlMatch[1] === "file" && schemaFileObject.playerType) {
 
@@ -57,7 +59,7 @@ module.exports = {
                 file["aspect-ratio"] = Math.sqrt(2); // A4 landscape
                 file.rel.push (CONFIG.R.reader);
 
-            } else { // presentation                
+            } else { // presentation
                 // file["aspect-ratio"] = 4/3; // use default aspect ratio
                 file.rel.push (CONFIG.R.player);
             }
@@ -87,7 +89,7 @@ module.exports = {
 
                 var key = $el.attr('itemprop');
                 if (key) {
-                    var value = decode($el.attr('content') || $el.attr('href'));
+                    var value = decodeHTML5(decode($el.attr('content') || $el.attr('href')));
                     result[key] = value;
                 }
             });
@@ -96,7 +98,7 @@ module.exports = {
                 schemaFileObject: result
             };
         }
-    }, 
+    },
 
     tests: [
         "https://docs.google.com/document/d/17jg1RRL3RI969cLwbKBIcoGDsPwqaEdBxafGNYGwiY4/preview?sle=true",


### PR DESCRIPTION
I've added `require('entities').decodeHTML5` to the Google Docs plugin to fix a bug where Google Form pre-filled links were not working. This was happening because the meta element in the Google Form body was already encoded (using `&amp;`) and it was not being decoded properly. Then the cheerio `.html()` function encodes it again which results in `&amp;amp;`.

Example link:
https://docs.google.com/forms/d/e/1FAIpQLSfboIYnzzSHcnpik8NR4m4Cxpej_epziD_orYuNdf2KDCrcUQ/viewform?entry.203129905=Text&entry.553456400=Option+2&entry.1746889772=Paragraph

Google form meta element:
```
<meta itemprop="embedURL" content="https://docs.google.com/forms/d/e/1FAIpQLSfboIYnzzSHcnpik8NR4m4Cxpej_epziD_orYuNdf2KDCrcUQ/viewform?entry.203129905=Text&amp;entry.553456400=Option+2&amp;entry.1746889772=Paragraph&amp;embedded=true&amp;usp=embed_googleplus">
```

Iframely html:
```
<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfboIYnzzSHcnpik8NR4m4Cxpej_epziD_orYuNdf2KDCrcUQ/viewform?entry.203129905=Text&amp;amp;entry.553456400=Option+2&amp;amp;entry.1746889772=Paragraph&amp;amp;embedded=true&amp;amp;usp=embed_googleplus" frameborder="0" allowfullscreen="" style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute;"></iframe>
```

I copied the format from [HTMLMetaHandler.js#L227](https://github.com/itteco/iframely/blob/dad276e2aed368b4f90f9a70523c806993b32a50/lib/plugins/system/meta/HTMLMetaHandler.js#L227) which uses `decodeHTML5(encodeText())`, however I think that only `decodeHTML5` is required. I didn't want to make any changes to the core because I only discovered iframely yesterday and I don't know if this bug only relates to the Google Docs plugin. Maybe a better approach would be better to use `decodeHTML5` or [he](https://github.com/mathiasbynens/he) in the `utils.encodeText` function.

All other changes are related to trailing whitespace and were cleaned automatically by my editor. If this is a problem I can only commit the two lines that are necessary.