### PR TITLE
add disableSizeWrapper to config

### DIFF
--- a/config.local.js.SAMPLE
+++ b/config.local.js.SAMPLE
@@ -29,11 +29,19 @@
             // /^https?:\/\/yourdomain\.com\//,
         ],
 
+        /*
+        // Used to pass parameters to the generate functions when creating HTML elements
+        // disableSizeWrapper: Don't wrap element (iframe, video, etc) in a positioned div
+        GENERATE_LINK_PARAMS: {
+            disableSizeWrapper: true
+        },
+        */
+
         port: 8061, //can be overridden by PORT env var
         host: '0.0.0.0',    // Dockers beware. See https://github.com/itteco/iframely/issues/132#issuecomment-242991246
                             //can be overridden by HOST env var
 
-        // Optional SSL cert, if you serve under HTTPS. 
+        // Optional SSL cert, if you serve under HTTPS.
         /*
         ssl: {
             key: require('fs').readFileSync(__dirname + '/key.pem'),
@@ -152,7 +160,7 @@
                 // media_only: true     // disables status embeds for images and videos - will return plain media
             },
             google: {
-                // https://developers.google.com/maps/documentation/embed/guide#api_key                
+                // https://developers.google.com/maps/documentation/embed/guide#api_key
                 maps_key: "INSERT YOUR VALUE"
             },
 
@@ -191,7 +199,7 @@
                     album: {
                         height: 472,
                         'max-width': 700
-                    }, 
+                    },
                     track: {
                         height: 120,
                         'max-width': 700
@@ -207,7 +215,7 @@
         // More about format: https://iframely.com/docs/qa-format
 
         /*
-        WHITELIST_WILDCARD: {  
+        WHITELIST_WILDCARD: {
               "twitter": {
                 "player": "allow",
                 "photo": "deny"

--- a/lib/oembed.js
+++ b/lib/oembed.js
@@ -109,9 +109,9 @@ exports.getOembed = function(uri, data, options) {
         } else {
             // "player", "survey", "reader"
 
-            oembed.html = htmlUtils.generateLinkElementHtml(link, {
-                iframelyData: data
-            });
+            var generateLinkParams = CONFIG.GENERATE_LINK_PARAMS || {};
+            _.extend(generateLinkParams, {iframelyData: data});
+            oembed.html = htmlUtils.generateLinkElementHtml(link, generateLinkParams);
 
             if (foundRel === CONFIG.R.player) {
                 oembed.type = 'video';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,12 +87,12 @@ var getUrl = exports.getUrl = function(url, options) {
 
                     var contentEncoding = res.headers['content-encoding'];
 	                contentEncoding = contentEncoding && contentEncoding.trim().toLowerCase();
-	
+
 	                var zlibOptions = {
 		                flush: zlib.Z_SYNC_FLUSH,
                         finishFlush: zlib.Z_SYNC_FLUSH
 	                };
-	
+
 	                if (supportGzip && (contentEncoding === 'gzip' || contentEncoding === 'deflate')) {
 
 		                var gunzip = contentEncoding === 'gzip' ? zlib.createGunzip(zlibOptions) : zlib.createInflate(zlibOptions);
@@ -100,11 +100,11 @@ var getUrl = exports.getUrl = function(url, options) {
 		                gunzip.request = res.request;
 		                gunzip.statusCode = res.statusCode;
 		                gunzip.headers = res.headers;
-		
+
 		                if (!options.asBuffer) {
 			                gunzip.setEncoding("binary");
 		                }
-		                
+
 		                req.emit('response', gunzip);
 		                res.pipe(gunzip);
 
@@ -113,7 +113,7 @@ var getUrl = exports.getUrl = function(url, options) {
 		                if (!options.asBuffer) {
 			                res.setEncoding("binary");
 		                }
-		
+
 		                req.emit('response', res);
 	                }
                 });
@@ -698,9 +698,9 @@ exports.generateLinksHtml = function(data, options) {
                 link.rel.push('autoplay');
             }
 
-            var html = htmlUtils.generateLinkElementHtml(link, {
-                iframelyData: data
-            });
+            var generateLinkParams = CONFIG.GENERATE_LINK_PARAMS || {};
+            _.extend(generateLinkParams, {iframelyData: data});
+            var html = htmlUtils.generateLinkElementHtml(link, generateLinkParams);
             if (html) {
                 link.html = html;
             }
@@ -723,9 +723,9 @@ exports.generateLinksHtml = function(data, options) {
             var html = mainLink.html;
 
             if (!html && mainLink.type.match(/^image/)) {
-                html = htmlUtils.generateLinkElementHtml(mainLink, {
-                    iframelyData: data
-                });
+                var generateLinkParams = CONFIG.GENERATE_LINK_PARAMS || {};
+                _.extend(generateLinkParams, {iframelyData: data});
+                html = htmlUtils.generateLinkElementHtml(mainLink, generateLinkParams);
             }
 
             if (html) {
@@ -884,6 +884,6 @@ function getWhitelistLogData(meta, oembed) {
             hasTrue = true;
         }
     }
-    
+
     return hasTrue && result;
 }


### PR DESCRIPTION
This is similar to pull request #152, but I've moved the parameter to the local config file and disabled it by default. I've also made it work for oEmbed.

This is useful for the project I work on because there is already a container with a defined size, and the iframe is then set to 100% width and height within it. The current size wrapper breaks the layout.