### PR TITLE
Allow for the editable google docs links instead of previews

### DIFF
--- a/config.local.js.SAMPLE
+++ b/config.local.js.SAMPLE
@@ -161,7 +161,9 @@
             },
             google: {
                 // https://developers.google.com/maps/documentation/embed/guide#api_key
-                maps_key: "INSERT YOUR VALUE"
+                maps_key: "INSERT YOUR VALUE",
+                // when 'true' use editable Google Docs links instead of previews
+                editableDocs: false
             },
 
             /*

--- a/plugins/domains/google.com/docs.google.com.js
+++ b/plugins/domains/google.com/docs.google.com.js
@@ -30,13 +30,18 @@ module.exports = {
 
     },
 
-    getLink: function(urlMatch, schemaFileObject) {
+    getLink: function(urlMatch, schemaFileObject, options) {
+        var href;
 
-        if (schemaFileObject.embedURL || schemaFileObject.embedUrl) {
+        if (urlMatch[1] !== 'file' && options.getProviderOptions('google.editableDocs')) href = schemaFileObject.url;
+
+        if (!href) href = schemaFileObject.embedURL || schemaFileObject.embedUrl;
+
+        if (href) {
 
             var file = {
                 rel: [CONFIG.R.file, CONFIG.R.html5],
-                href: schemaFileObject.embedURL || schemaFileObject.embedUrl,
+                href: href,
                 type: CONFIG.T.text_html
             };
 


### PR DESCRIPTION
Add config option to google's provider options to make use of the editable link instead of the preview link when embedding a google doc.

Instead of: 
![screen shot 2017-05-19 at 13 29 31](https://cloud.githubusercontent.com/assets/7109418/26246000/46bcfa86-3c97-11e7-9751-2c6d880b1f26.png)

Display:
![screen shot 2017-05-19 at 13 29 49](https://cloud.githubusercontent.com/assets/7109418/26246138/dcd1e82e-3c97-11e7-8712-fcaba2748213.png)


