### PR TITLE
fix: override custom templates same as plugins

### DIFF
--- a/lib/loader/pluginLoader.js
+++ b/lib/loader/pluginLoader.js
@@ -289,8 +289,13 @@
             var id = getFileName(bits[bits.length - 1]).toLowerCase();
 
             if (id in templates) {
-                console.error("Duplicate template id (filename)", pluginPath);
-                return;
+                if (CONFIG.CUSTOM_PLUGINS_PATH && pluginPath.indexOf(CONFIG.CUSTOM_PLUGINS_PATH) > -1) {
+                    console.error("Template '" + id + "' overridden by", pluginPath);
+                    delete templates[id]
+                } else {
+                    console.error("Duplicate template id (filename)", pluginPath);
+                        return;
+                }
             }
 
             templates[id] = pluginPath;


### PR DESCRIPTION
When loading duplicate plugins there's logic to decide wether to ignore them or if the duplicate is loaded from `CONFIG.CUSTOM_PLUGINS_PATH` to override the currently loaded plugin with the new one.

This adds the same logic to the loading of `ejs` templates.

See: https://github.com/itteco/iframely/blob/master/lib/loader/pluginLoader.js#L188 for the plugin override part.