### PR TITLE
add support for bulk oembed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:5.8
+#FROM node:5.8
+FROM arm64v8/node:6.11.2
 
 EXPOSE 8061
 

--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 var sysUtils = require('./utils');
+var bodyParser = require('body-parser')
 
 console.log("");
 console.log("Starting Iframely...");
@@ -35,7 +36,7 @@ app.use(function(req, res, next) {
   res.setHeader('X-Powered-By', 'Iframely');
   next();
 });
-
+app.use(bodyParser.json());
 app.use(sysUtils.cacheMiddleware);
 
 
@@ -122,16 +123,16 @@ function errorHandler(err, req, res, next) {
     }
     else if (code === 404) {
       respondWithError(req, res, 404, 'Not found');
-    }    
+    }
     else if (code === 410) {
       respondWithError(req, res, 410, 'Gone');
     }
     else if (code === 415) {
       respondWithError(req, res, 415, 'Unsupported Media Type');
-    } 
+    }
     else if (code === 417) {
       respondWithError(req, res, 417, 'Unsupported Media Type');
-    }    
+    }
     else {
       respondWithError(req, res, code, 'Server error');
     }

--- a/modules/api/views.js
+++ b/modules/api/views.js
@@ -8,7 +8,7 @@ var oembedUtils = require('../../lib/oembed');
 var whitelist = require('../../lib/whitelist');
 var pluginLoader = require('../../lib/loader/pluginLoader');
 var jsonxml = require('jsontoxml');
-var bodyParser = require('body-parser')
+
 
 function prepareUri(uri) {
 
@@ -470,9 +470,7 @@ module.exports = function(app) {
       })
     }
 
-    var jsonParser = bodyParser.json()
-
-    app.post('/oembed.bulk',jsonParser,function(req, res, next) {
+    app.post('/oembed.bulk',function(req, res, next) {
 
         if (!req.body.urls || req.body.urls.length==0) {
               return next(new Error("'urls' post param expected"));

--- a/modules/api/views.js
+++ b/modules/api/views.js
@@ -8,6 +8,7 @@ var oembedUtils = require('../../lib/oembed');
 var whitelist = require('../../lib/whitelist');
 var pluginLoader = require('../../lib/loader/pluginLoader');
 var jsonxml = require('jsontoxml');
+var bodyParser = require('body-parser')
 
 function prepareUri(uri) {
 
@@ -420,6 +421,75 @@ module.exports = function(app) {
 
             //iframely.disposeObject(result);
         });
+    });
+
+    let processUrlOEmbed = (req,url,cb) => {
+        var uri = prepareUri(url);
+        if (!uri) {
+            return cb({url:url,error:"empty url"});
+        }
+
+        if (!CONFIG.DEBUG && uri.split('/')[2].indexOf('.') === -1) {
+            return cb({url:url,error:"local domains not supported"});
+        }
+
+        log(req, 'Loading /oembed for', uri);
+
+        async.waterfall([
+
+            function(wcb) {
+
+                iframelyCore.run(uri, {
+                    getWhitelistRecord: whitelist.findWhitelistRecordFor,
+                    filterNonSSL: getBooleanParam(req, 'ssl'),
+                    filterNonHTML5: getBooleanParam(req, 'html5'),
+                    maxWidth: getIntParam(req, 'maxwidth') || getIntParam(req, 'max-width'),
+                    refresh: getBooleanParam(req, 'refresh')
+                }, wcb);
+            }
+
+        ], function(error, result) {
+
+            if (error) {
+                return cb({url:url,error:error},null)
+            }
+
+            iframelyCore.sortLinks(result.links);
+
+            iframelyUtils.filterLinks(result, {
+                filterNonSSL: getBooleanParam(req, 'ssl'),
+                filterNonHTML5: getBooleanParam(req, 'html5'),
+                maxWidth: getIntParam(req, 'maxwidth') || getIntParam(req, 'max-width')
+            });
+
+            var oembed = oembedUtils.getOembed(uri, result, {
+                mediaPriority: getBooleanParam(req, 'media'),
+                omit_css: getBooleanParam(req, 'omit_css')
+            });
+            cb(null,oembed)
+      })
+    }
+
+    var jsonParser = bodyParser.json()
+
+    app.post('/oembed.bulk',jsonParser,function(req, res, next) {
+
+        if (!req.body.urls || req.body.urls.length==0) {
+              return next(new Error("'urls' post param expected"));
+        }
+        var urls = req.body.urls.slice(0,10)
+        let curriedProcessUrlOEmbed = processUrlOEmbed.bind(undefined,req)
+        async.map(urls,async.reflect(curriedProcessUrlOEmbed),function(err,result) {
+          if (err) {
+              return handleIframelyError(error, res, next);
+          }
+          let [errors,results] = _.partition(result,(r) => r.error)
+          let errorUrls = _.pluck(errors,'error')
+          let resultUrls = _.pluck(results,'value')
+          let response = {errors:errorUrls,results:resultUrls}
+          res.jsonpCached(response);
+        });
+
     });
 
 };

--- a/package.json
+++ b/package.json
@@ -1,64 +1,65 @@
 {
-    "name": "iframely",
-    "version": "1.1.0",
-    "description": "oEmbed/2 gateway endpoint. Get embed data for various http links through one self-hosted API",
-    "keywords": [
-        "oembed",
-        "embed",
-        "open graph",
-        "og",
-        "twitter cards"
-    ],
-    "homepage": "http://iframely.com",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/itteco/iframely.git"
-    },
-    "bugs": {
-        "url": "https://github.com/itteco/iframely/issues"
-    },
-    "license": "MIT",
-    "dependencies": {
-        "async": "2.4.1",
-        "cheerio": "0.22.0",
-        "chokidar": "1.7.0",
-        "ejs": "2.3.4",
-        "entities": "1.1.1",
-        "express": "^4.15.3",
-        "graceful-cluster": "0.0.3",
-        "htmlparser2": "3.9.2",
-        "http-parser-js": "^0.4.5",
-        "iconv-lite": "0.4.17",
-        "imagesize": "1.0.0",
-        "jslint": "0.8",
-        "jsontoxml": "0.0.11",
-        "memcached": "2.2.2",
-        "moment": "2.18.1",
-        "node-cache": "1.*",
-        "parse-iso-duration": "1.0.0",
-        "readabilitySAX": "1.6.1",
-        "redis": "2.7.1",
-        "request": "2.81.0",
-        "sax": "1.2.2",
-        "send": "0.15.3",
-        "underscore": "1.8.3"
-    },
-    "devDependencies": {
-        "vows": "0.7.0",
-        "feedparser": "2.2.0",
-        "mongoose": "4.10.5",
-        "chai": "^3.5.0",
-        "mocha": "^3.1.2",
-        "mock-http-server": "0.0.4",
-        "supertest": "^2.0.0"
-    },
-    "iframely-proxy-plugins": true,
-    "main": "./lib/core",
-    "scripts": {
-        "test": "vows test/main.js --isolate --spec && npm run test-e2e",
-        "test-e2e": "NODE_ENV=test PORT=8080 mocha test"
-    },
-    "engines": {
-        "node": ">=0.10.21"
-    }
+  "name": "iframely",
+  "version": "1.1.0",
+  "description": "oEmbed/2 gateway endpoint. Get embed data for various http links through one self-hosted API",
+  "keywords": [
+    "oembed",
+    "embed",
+    "open graph",
+    "og",
+    "twitter cards"
+  ],
+  "homepage": "http://iframely.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/itteco/iframely.git"
+  },
+  "bugs": {
+    "url": "https://github.com/itteco/iframely/issues"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "async": "2.4.1",
+    "body-parser": "^1.17.2",
+    "cheerio": "0.22.0",
+    "chokidar": "1.7.0",
+    "ejs": "2.3.4",
+    "entities": "1.1.1",
+    "express": "^4.15.3",
+    "graceful-cluster": "0.0.3",
+    "htmlparser2": "3.9.2",
+    "http-parser-js": "^0.4.5",
+    "iconv-lite": "0.4.17",
+    "imagesize": "1.0.0",
+    "jslint": "0.8",
+    "jsontoxml": "0.0.11",
+    "memcached": "2.2.2",
+    "moment": "2.18.1",
+    "node-cache": "1.*",
+    "parse-iso-duration": "1.0.0",
+    "readabilitySAX": "1.6.1",
+    "redis": "2.7.1",
+    "request": "2.81.0",
+    "sax": "1.2.2",
+    "send": "0.15.3",
+    "underscore": "1.8.3"
+  },
+  "devDependencies": {
+    "vows": "0.7.0",
+    "feedparser": "2.2.0",
+    "mongoose": "4.10.5",
+    "chai": "^3.5.0",
+    "mocha": "^3.1.2",
+    "mock-http-server": "0.0.4",
+    "supertest": "^2.0.0"
+  },
+  "iframely-proxy-plugins": true,
+  "main": "./lib/core",
+  "scripts": {
+    "test": "vows test/main.js --isolate --spec && npm run test-e2e",
+    "test-e2e": "NODE_ENV=test PORT=8080 mocha test"
+  },
+  "engines": {
+    "node": ">=0.10.21"
+  }
 }

--- a/utils.js
+++ b/utils.js
@@ -104,6 +104,8 @@
         var urlObj = urlLib.parse(req.url, true);
 
         var query = urlObj.query;
+        var postUrls = req.body.urls
+        postUrls.sort()
 
         delete query.refresh;
 
@@ -124,6 +126,7 @@
         keys.forEach(function(key) {
             newQuery[key] = query[key];
         });
+        newQuery['urls'] = postUrls
 
         urlObj.query = newQuery;
 
@@ -188,7 +191,7 @@
 
                                 if (head) {
 
-                                    log(req, "Using cache for", req.url.replace(/\?.+/, ''), req.query.uri || req.query.url);
+                                    log(req, "Using cache for", req.url.replace(/\?.+/, ''), req.query.uri || req.query.url || req.body.urls);
 
                                     var requestedEtag = req.headers['if-none-match'];
 


### PR DESCRIPTION
a POST endpoint /oembed.bulk with json input {urls:[]}
currently limits the size of urls to 10
added body urls signature to response cache