### PR TITLE
Export ID of YouTube videos

### DIFF
--- a/plugins/domains/youtube.com/youtube.video.js
+++ b/plugins/domains/youtube.com/youtube.video.js
@@ -109,6 +109,7 @@ module.exports = {
 
     getMeta: function(youtube_video_gdata) {
         return {
+            id: youtube_video_gdata.id,
             title: youtube_video_gdata.title,
             date: youtube_video_gdata.uploaded,
             author: youtube_video_gdata.uploader,


### PR DESCRIPTION
Instead of extracting the video ID from the URL, I find it more convenient to have it in the data returned by iframely.