### PR TITLE
Fix: Extend Soundcloud oEmbed regex to match all possible URLs

### DIFF
--- a/lib/plugins/system/oembed/providers.json
+++ b/lib/plugins/system/oembed/providers.json
@@ -59,7 +59,7 @@
         "name": "SoundCloud",
         "templates": [
             "soundcloud\\.com/.+",
-            "api\\.soundcloud\\.com\/tracks\\/\\d+"
+            "api\\.soundcloud\\.com\/(?:users|playlists|tracks)\\/\\d+"
         ],
         "endpoint": "http://soundcloud.com/oembed"
     },


### PR DESCRIPTION
The Soundcloud oEmbed endpoint also accepts user and playlist API URLs. This PR modifies the regular expression for Soundcloud so that it also matches those URLs.

https://soundcloud.com/oembed?url=http://api.soundcloud.com/users/3207
https://soundcloud.com/oembed?url=http://api.soundcloud.com/playlists/808868352