### PR TITLE
Fix: Extend Carto oEmbed regex to match all possible URLs

### DIFF
--- a/lib/plugins/system/oembed/providers.json
+++ b/lib/plugins/system/oembed/providers.json
@@ -398,7 +398,7 @@
     {
         "name": "carto.com",
         "templates": [
-            "\\w+.carto(?:db)?\\.com/(?:u\/[a-zA-Z0-9-]+/)?viz/[a-z0-9-]+"
+            "[\\w-]+.carto(?:db)?\\.com/(?:u\/[a-zA-Z0-9-]+/)?(?:viz|builder)/[a-z0-9-]+(?:/\\w+)?"
         ],
         "endpoint": "http://services.carto.com/oembed"
     },


### PR DESCRIPTION
This PR modifies the regular expression for Carto so that it also matches URLs for Carto usernames containing a dash and Carto Builder widgets.

Example: https://hendrik-lehmann.carto.com/builder/d2e08cd9-83ba-4297-b02f-7f06b5282694/embed

Carto oEmbed request: http://services.carto.com/oembed?url=https://hendrik-lehmann.carto.com/builder/d2e08cd9-83ba-4297-b02f-7f06b5282694/embed