### PR TITLE
feat: Add whitelist extend option

### DIFF
--- a/config.js
+++ b/config.js
@@ -22,6 +22,7 @@
 
         WHITELIST_URL: 'https://iframely.com/qa/whitelist.json',
         WHITELIST_URL_RELOAD_PERIOD: 60 * 60 * 1000,  // will reload WL every hour, if no local files are found in /whitelist folder
+        WHITELIST_EXTEND: false,
 
         WHITELIST_WILDCARD: {},
         WHITELIST_LOG_URL: 'https://iframely.com/whitelist-log',

--- a/config.local.js.SAMPLE
+++ b/config.local.js.SAMPLE
@@ -7,6 +7,9 @@
         DEBUG: false,
         RICH_LOG_ENABLED: false,
 
+        // add custom whitelist to Iframely whitelist instead of replacing it
+        WHITELIST_EXTEND: false,
+
         // For embeds that require render, baseAppUrl will be used as the host.
         baseAppUrl: "http://yourdomain.com",
         relativeStaticUrl: "/r",

--- a/lib/whitelist.js
+++ b/lib/whitelist.js
@@ -10,6 +10,8 @@
         logging = require('../logging');
 
     var whitelistObject = {domains: {}};
+    var whitelistObjectIframely = {domains: {}};
+    var whitelistObjectCustom = {domains: {}};
     var whitelistLastModified;
     var currentWhitelistFilename;
     var WHITELIST_DIR = path.resolve(__dirname, '../whitelist');
@@ -214,17 +216,33 @@
 
     function applyParsedWhitelist(data) {
 
-        if (whitelistObject && whitelistObject.domains) {
-            delete whitelistObject.domains["*"];
+        whitelistObjectIframely = data;
+
+        if (CONFIG.WHITELIST_EXTEND) {
+            whitelistObject.domains = _.extend(whitelistObjectIframely.domains, whitelistObjectCustom.domains);
+        } else {
+            whitelistObject = data;
         }
-
-        //utils.disposeObject(whitelistObject);
-
-        whitelistObject = data;
 
         addWildcard();
 
         logging.log('Whitelist activated. Domains, including blacklisted:', _.keys(data.domains).length);
+    }
+
+    function applyParsedCustomWhitelist(data) {
+
+        whitelistObjectCustom = data;
+
+        if (CONFIG.WHITELIST_EXTEND) {
+            whitelistObject.domains = _.extend(whitelistObjectIframely.domains, whitelistObjectCustom.domains);
+        } else {
+            whitelistObject = data;
+        }
+
+        addWildcard();
+
+        logging.log('Custom whitelist activated. Domains, including blacklisted:', _.keys(data.domains).length);
+
     }
 
     function readWhitelist(filename) {
@@ -240,7 +258,7 @@
 
         if (newWhitelist) {
 
-            applyParsedWhitelist(newWhitelist);
+            applyParsedCustomWhitelist(newWhitelist);
 
             currentWhitelistFilename = filename;
         }
@@ -324,7 +342,7 @@
 
     function loadWhitelistUrl() {
 
-        if (!currentWhitelistFilename && CONFIG.WHITELIST_URL && CONFIG.WHITELIST_URL_RELOAD_PERIOD) {
+        if ((CONFIG.WHITELIST_EXTEND || !currentWhitelistFilename) && CONFIG.WHITELIST_URL && CONFIG.WHITELIST_URL_RELOAD_PERIOD) {
 
             logging.log("Loading whitelist from " + CONFIG.WHITELIST_URL);
 


### PR DESCRIPTION
This PR introduces a new, optional config option WHITELIST_EXTEND. If it is set to true, the whitelist provided by IFramely will be extended with the domain entries from the local whitelist instead of replacing it, while continuing to regularly update the remote Iframely whitelist and watch for changes in the local whitelist folder.

By default WHITELIST_EXTEND is set to false and doesn't change the current behavior, so this is no breaking change. 