### PR TITLE
Fix `config.local.js.SAMPLE` syntax by removing superfluous */

### DIFF
--- a/config.local.js.SAMPLE
+++ b/config.local.js.SAMPLE
@@ -137,9 +137,9 @@
         */
          }],
 
-        /* Configure use of HTTP proxies as needed. 
-           You don't have to specify all options per regex - just what you need to override
-        */
+        /*
+        // Configure use of HTTP proxies as needed.
+        // You don't have to specify all options per regex - just what you need to override
         PROXY: [{
             re: [/^https?:\/\/www\.domain\.com/],
             proxy_server: 'http://1.2.3.4:8080',


### PR DESCRIPTION
In `config.local.js.SAMPLE` there's one too many `*/`, thus rendering the file syntactically invalid:

https://github.com/itteco/iframely/blob/7c73f40212c34cf3e1cb0de134ee45034a8de64d/config.local.js.SAMPLE#L140-L157

This commit removes the first `*/` (line 142) in favour of the later one (line 157), making the `PROXY` configuration setting commented-out by default.

(See earlier commits e0800fdec and 5459d5a87 which led to the current error.)