### PR TITLE
Added modifiable Access-Control-Allow-Headers

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,14 +30,14 @@ if (CONFIG.allowedOrigins) {
                     res.setHeader('Access-Control-Allow-Origin', origin);
                 }
             }
-            if (CONFIG.allowedHeaders) {
-                if (CONFIG.allowedHeaders.indexOf('*') > -1) {
-                    res.setHeader('Access-Control-Allow-Headers', '*');
-                } else {
-                    if (CONFIG.allowedHeaders.indexOf(requestHeader) > -1) {
-                        res.setHeader('Access-Control-Allow-Headers', requestHeader);
-                    }
-                }
+        }
+        if (requestHeader) {
+            if (CONFIG.allowedHeaders.indexOf('*') > -1) {
+                res.setHeader('Access-Control-Allow-Headers', '*');
+            } else {
+                if (CONFIG.allowedHeaders.indexOf(requestHeader) > -1) {
+                    res.setHeader('Access-Control-Allow-Headers', requestHeader);
+                 }
             }
         }
         next();

--- a/app.js
+++ b/app.js
@@ -19,21 +19,30 @@ var app = express();
 app.set('view engine', 'ejs');
 
 if (CONFIG.allowedOrigins) {
-  app.use(function(req, res, next) {
-    var origin = req.headers["origin"];
-
-    if (origin) {
-      if (CONFIG.allowedOrigins.indexOf('*') > -1) {
-        res.setHeader('Access-Control-Allow-Origin', '*');
-      } else {
-        if (CONFIG.allowedOrigins.indexOf(origin) > -1) {
-          res.setHeader('Access-Control-Allow-Origin', origin);
+    app.use(function(req, res, next) {
+        var origin = req.headers["origin"];
+        var requestHeader = req.headers["access-control-request-headers"];
+        if (origin) {
+            if (CONFIG.allowedOrigins.indexOf('*') > -1) {
+                res.setHeader('Access-Control-Allow-Origin', '*');
+            } else {
+                if (CONFIG.allowedOrigins.indexOf(origin) > -1) {
+                    res.setHeader('Access-Control-Allow-Origin', origin);
+                }
+            }
+            if (CONFIG.allowedHeaders) {
+                if (CONFIG.allowedHeaders.indexOf('*') > -1) {
+                    res.setHeader('Access-Control-Allow-Headers', '*');
+                } else {
+                    if (CONFIG.allowedHeaders.indexOf(requestHeader) > -1) {
+                        res.setHeader('Access-Control-Allow-Headers', requestHeader);
+                    }
+                }
+            }
         }
-      }
-    }
-    next();
-  });
-}
+        next();
+    })
+};
 app.disable( 'x-powered-by' );
 app.use(function(req, res, next) {
   res.setHeader('X-Powered-By', 'Iframely');

--- a/config.local.js.SAMPLE
+++ b/config.local.js.SAMPLE
@@ -86,6 +86,14 @@
         */
 
         /*
+        // Access-Control-Allow-Headers list.
+        allowedHeaders: [
+            "*",
+            "content-type"
+        ],
+        */
+
+        /*
         // Uncomment to enable plugin testing framework.
         tests: {
             mongodb: 'mongodb://localhost:27017/iframely-tests',


### PR DESCRIPTION
Added modifiable Access-Control-Allow-Headers list to sample config and app.js . Without setting accepted headers browser CORS requests, by default, return "Request header field *xxx* is not allowed by Access-Control-Allow-Headers in preflight response".