### PR TITLE
lib: add missing url encoding for some known oembed providers

### DIFF
--- a/lib/plugins/system/oembed/oembedUtils.js
+++ b/lib/plugins/system/oembed/oembedUtils.js
@@ -53,6 +53,11 @@ function lookupStaticProviders(uri) {
                     var n = parseInt(g.match(/\{(\d+)\}/)[1]);
                     endpoint = endpoint.replace("{" + n + "}", match[n]);
                 });
+                
+                var u = endpoint.match(/\{\{(.+)\}\}/);
+                if (u && u[1]) {
+                    endpoint = endpoint.replace(/(\{\{.+\}\})/, encodeURIComponent(u[1]));
+                }
 
             } else if (endpoint.match(/\{url\}/)) {
                 endpoint = endpoint.replace(/\{url\}/, encodeURIComponent(uri));

--- a/lib/plugins/system/oembed/oembedUtils.js
+++ b/lib/plugins/system/oembed/oembedUtils.js
@@ -45,25 +45,29 @@ function lookupStaticProviders(uri) {
 
         if (match) {
 
+            function replaceParts (str) {
+                var s = str;
+                var groups = str && str.match(/\{\d+\}/g);
+                if (groups) {
+                    groups.forEach(function(g) {
+                        var n = parseInt(g.match(/\{(\d+)\}/)[1]);
+                        s = s.replace("{" + n + "}", match[n]);
+                    })
+                }
+                return s;
+            }
+
+            var canonical = replaceParts(p.url);
             var endpoint = p.endpoint;
 
-            var groups = endpoint.match(/\{\d+\}/g);
-            if (groups) {
-                groups.forEach(function(g) {
-                    var n = parseInt(g.match(/\{(\d+)\}/)[1]);
-                    endpoint = endpoint.replace("{" + n + "}", match[n]);
-                });
-                
-                var u = endpoint.match(/\{\{(.+)\}\}/);
-                if (u && u[1]) {
-                    endpoint = endpoint.replace(/(\{\{.+\}\})/, encodeURIComponent(u[1]));
-                }
+            if (/\{\d+\}/i.test(endpoint)) {
+                endpoint = replaceParts(endpoint);
 
             } else if (endpoint.match(/\{url\}/)) {
-                endpoint = endpoint.replace(/\{url\}/, encodeURIComponent(uri));
+                endpoint = endpoint.replace(/\{url\}/, encodeURIComponent(canonical || uri));
 
             } else {
-                endpoint = endpoint + '?url=' + encodeURIComponent(uri);
+                endpoint = endpoint + '?url=' + encodeURIComponent(canonical || uri);
             }
 
             links = ['json', 'xml'].map(function(format) {

--- a/lib/plugins/system/oembed/providers.json
+++ b/lib/plugins/system/oembed/providers.json
@@ -71,7 +71,7 @@
             "(?:www\\.)?flickr\\.com/(photos/[@a-zA-Z0-9_\\.-]+/\\d+.*?$)",
             "(?:www\\.)?flickr\\.com/(photos/[@a-zA-Z0-9_\\.-]+/(?:sets|albums)/(?:\\d+))"
         ],
-        "endpoint": "https://www.flickr.com/services/oembed/?format={format}&url=https://www.flickr.com/{1}"
+        "endpoint": "https://www.flickr.com/services/oembed/?format={format}&url={{https://www.flickr.com/{1}}}"
     },
     {
         "name": "Brightcove",
@@ -92,7 +92,7 @@
         "templates": [
             "((?:\\w+\\.)?scribd\\.com)/(?:doc|document|embeds|presentation|fullscren)/(.*)"
         ],
-        "endpoint": "https://www.scribd.com/services/oembed?format={format}&url=https://{1}/doc/{2}"
+        "endpoint": "https://www.scribd.com/services/oembed?format={format}&url={{https://{1}/doc/{2}}}"
     },
     {
         "name": "Viddler",
@@ -119,7 +119,7 @@
             "www\\.youtube\\.com/user/[a-zA-Z0-9_-]+\\?v=([a-zA-Z0-9_-]+)",
             "www\\.youtube-nocookie\\.com/v/([a-zA-Z0-9_-]+)"
         ],
-        "endpoint": "https://www.youtube.com/oembed?format={format}&url=https://www.youtube.com/watch?v={1}"
+        "endpoint": "https://www.youtube.com/oembed?format={format}&url={{https://www.youtube.com/watch?v={1}}}"
     },
     {
         "name": "YouTube Playlist",
@@ -358,7 +358,7 @@
         "templates": [
             "(?:open|embed|play)\\.spotify\\.com/(?:embed/)?([^\\?]*)\\??.*"
         ],
-        "endpoint": "https://open.spotify.com/oembed?url=https://open.spotify.com/{1}&format={format}"
+        "endpoint": "https://open.spotify.com/oembed?url={{https://open.spotify.com/{1}}}&format={format}"
     },
     {
         "name": "Issuu",
@@ -533,7 +533,7 @@
         "templates": [
             "(?:www\\.)producthunt\\.com/posts/[^#]+#comments?\\-(\\d+)"
         ],
-        "endpoint": "https://api.producthunt.com/widgets/oembed?url=https://www.producthunt.com/comments/{1}"
+        "endpoint": "https://api.producthunt.com/widgets/oembed?url={{https://www.producthunt.com/comments/{1}}}"
     }, {
         "name": "Office Forms",
         "templates": [        

--- a/lib/plugins/system/oembed/providers.json
+++ b/lib/plugins/system/oembed/providers.json
@@ -71,7 +71,8 @@
             "(?:www\\.)?flickr\\.com/(photos/[@a-zA-Z0-9_\\.-]+/\\d+.*?$)",
             "(?:www\\.)?flickr\\.com/(photos/[@a-zA-Z0-9_\\.-]+/(?:sets|albums)/(?:\\d+))"
         ],
-        "endpoint": "https://www.flickr.com/services/oembed/?format={format}&url={{https://www.flickr.com/{1}}}"
+        "url": "https://www.flickr.com/{1}",
+        "endpoint": "https://www.flickr.com/services/oembed/?format={format}&url={url}"
     },
     {
         "name": "Brightcove",
@@ -92,7 +93,8 @@
         "templates": [
             "((?:\\w+\\.)?scribd\\.com)/(?:doc|document|embeds|presentation|fullscren)/(.*)"
         ],
-        "endpoint": "https://www.scribd.com/services/oembed?format={format}&url={{https://{1}/doc/{2}}}"
+        "url": "https://{1}/doc/{2}",
+        "endpoint": "https://www.scribd.com/services/oembed?format={format}&url={url}"
     },
     {
         "name": "Viddler",
@@ -119,7 +121,8 @@
             "www\\.youtube\\.com/user/[a-zA-Z0-9_-]+\\?v=([a-zA-Z0-9_-]+)",
             "www\\.youtube-nocookie\\.com/v/([a-zA-Z0-9_-]+)"
         ],
-        "endpoint": "https://www.youtube.com/oembed?format={format}&url={{https://www.youtube.com/watch?v={1}}}"
+        "url": "https://www.youtube.com/watch?v={1}",
+        "endpoint": "https://www.youtube.com/oembed?format={format}&url={url}"
     },
     {
         "name": "YouTube Playlist",
@@ -358,7 +361,8 @@
         "templates": [
             "(?:open|embed|play)\\.spotify\\.com/(?:embed/)?([^\\?]*)\\??.*"
         ],
-        "endpoint": "https://open.spotify.com/oembed?url={{https://open.spotify.com/{1}}}&format={format}"
+        "url": "https://open.spotify.com/{1}",
+        "endpoint": "https://open.spotify.com/oembed?url={url}&format={format}"
     },
     {
         "name": "Issuu",
@@ -533,7 +537,8 @@
         "templates": [
             "(?:www\\.)producthunt\\.com/posts/[^#]+#comments?\\-(\\d+)"
         ],
-        "endpoint": "https://api.producthunt.com/widgets/oembed?url={{https://www.producthunt.com/comments/{1}}}"
+        "url": "https://www.producthunt.com/comments/{1}",
+        "endpoint": "https://api.producthunt.com/widgets/oembed?url={url}"
     }, {
         "name": "Office Forms",
         "templates": [        


### PR DESCRIPTION
While debugging Scribd with `?secret=` in URLs I noticed that we skip it in oEmbed discovery. 

Some other known oEmbed providers are probably missing URL encoding of `&url=...` parameter. 

It is likely non-issue at the moment because Request lib fixes it for us. But should we do it properly on our own? 

Introducing {{...}} markup for html  in known endpoints, as in `&url={{https://....}}`