### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-alpine
+FROM node:12-alpine
 
 EXPOSE 8061
 


### PR DESCRIPTION
Changed to node:12-alpine because npm install fails with lots of errors on node v14.