### PR TITLE
Fixes #248. Enforcing Node version in Docker to be 12.13.1 to workaro…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
 .gitignore
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:12.13.1-alpine
 
 EXPOSE 8061
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CONTAINER	:= iframely
 HUB_USER	:= ${USER}
 IMAGE_NAME	:= ${HUB_USER}/${CONTAINER}
-VERSION		:= v1.3.1
+VERSION		:= ${VERSION}
 EXPOSEPORT	:= 8061
 PUBLISHPORT := ${EXPOSEPORT}
 
@@ -13,6 +13,7 @@ build:
 	git checkout tag-${VERSION}
 	docker \
 		build \
+		--pull \
 		--rm --tag=${CONTAINER} .
 	@echo Image tag: ${VERSION}
 
@@ -26,8 +27,9 @@ run:
 		--tty \
 		--hostname=${CONTAINER} \
 		--name=${CONTAINER} \
+		-e NODE_TLS_REJECT_UNAUTHORIZED=0 \
 		-p ${PUBLISHPORT}:${EXPOSEPORT} \
-		-v $(PWD)/config.local.js.SAMPLE:/iframely/config.local.js \
+		-v $(PWD)/config.local.js:/iframely/config.local.js \
 		$(CONTAINER)
 
 shell:
@@ -40,7 +42,7 @@ shell:
 		--name=${CONTAINER} \
 		-p ${PUBLISHPORT}:${EXPOSEPORT} \
 		--entrypoint "/bin/ash" \
-		-v $(PWD)/config.local.js.SAMPLE:/iframely/config.local.js \
+		-v $(PWD)/config.local.js:/iframely/config.local.js \
 		$(CONTAINER) 
 
 exec:
@@ -67,10 +69,11 @@ clean:
 		rm ${CONTAINER}
 	-docker \
 		rmi ${CONTAINER}
-	git checkout master
-	git branch -d ${VERSION}
+	git branch -d tag-${VERSION}
 
 push:
-	docker tag ${CONTAINER} ${IMAGE_NAME}:${VERSION} && docker push ${IMAGE_NAME}
+	docker tag ${CONTAINER} ${IMAGE_NAME}:${VERSION} # && docker push ${IMAGE_NAME}
+	docker tag ${CONTAINER} ${IMAGE_NAME}:latest
+	docker push ${IMAGE_NAME}
 
 restart: stop clean run

--- a/docs/DOCKER-BUILD-INSTRUCTION.md
+++ b/docs/DOCKER-BUILD-INSTRUCTION.md
@@ -6,23 +6,24 @@ Get upstream changes
 
     git fetch upstream
 
-Check if there is new version with git tags: 
+Check if there is new version with git tags:
 
     git tag | tail -n 1
 
-Latest I pushed was v1.3.NN (this is an example!)
+Check if the tag/version is higher then what you are already running.
 
-## If newer:
+## Build new version
 
-Update Makefile with the new version
+Export the VERSION shell variable
 
-    $EDITOR Makefile
+    export VERSION=$(git tag | tail -n 1)
+    echo $VERSION
 
-(the makefile will switch to new branch and build it)
+Run `make` and the Makefile uses the $VERSION variable to checkout the new version and build it.
 
     make
 
-Ignore any OSX/Darwin warnings for npm 
+Ignore any OSX/Darwin warnings for npm, feel free to contribute by fixing the dependencies if you are able to.
 
     make run
 
@@ -30,7 +31,7 @@ It's now running in the background, lets check the logs:
 
     docker logs iframely
 
-Go to [iframely on localhost](http://localhost:8061/debug) 
+Go to [iframely on localhost](http://localhost:8061/debug)
 If it looks good, lets tag and push to docker hub:
 
     make push
@@ -38,18 +39,19 @@ If it looks good, lets tag and push to docker hub:
 Last step is to commit any changes with git cm, and finally
 
     git checkout master
-    git merge tag-<version>
-    git tag <version>
-    git push (to our repo).
-    git push origin <version>
+    git merge tag-$VERSION
+
+Push to our repo (code + tags)
+
+    git push
+    git push origin $VERSION
 
 # Ansible
 
-If you want to use Ansible to deploy your iframely container, copy the ansible-docker-iframely directory to 
-your ansible roles dir and the playbook to the playbook dir. and run the playbook:
+If you want to use Ansible to deploy your iframely container, copy the ansible-docker-iframely directory to your ansible roles dir and the playbook to the playbook dir. and run the playbook:
 
 ```
-ansible-playbook playbooks/iframely.yml 
+ansible-playbook playbooks/iframely.yml
 ```
 
 Verify iframely:
@@ -59,4 +61,3 @@ Go to [iframely on my host](https://<hostname.example.com>/iframely?uri=https%3A
 
 You can run tests and setups yourself with the vagrant file in the ansible-docker-iframely directory. Just cd
 there and run `vagrant up`.
-


### PR DESCRIPTION
- Fixes #248. 
- Enforce Node version in Docker to be 12.13.1 to workaround the timeout issue. 
- Upstream changes from @joltcan PR #294