### PR TITLE
DocumentCloud url with unicode characters causes 400 in oEmbed API

### DIFF
--- a/lib/plugins/system/oembed/providers.json
+++ b/lib/plugins/system/oembed/providers.json
@@ -751,9 +751,9 @@
     {
         "name": "Documentcloud",
         "templates": [
-            "documentcloud.org/documents/(\\d+)\\-([a-zA-Z0-9\\-]+|\\-).*"
+            "documentcloud.org/documents/(\\d+)-(?:[^./]+)?([./].+)"
         ],
-        "url": "https://www.documentcloud.org/documents/{1}-{2}.html",
+        "url": "https://www.documentcloud.org/documents/{1}--{2}",
         "endpoint": "https://www.documentcloud.org/api/oembed.json"
     }
 ]

--- a/lib/plugins/system/oembed/providers.json
+++ b/lib/plugins/system/oembed/providers.json
@@ -751,7 +751,7 @@
     {
         "name": "Documentcloud",
         "templates": [
-            "documentcloud.org/documents/(\\d+)\\-([^%.]+|\\-).*"
+            "documentcloud.org/documents/(\\d+)\\-([a-zA-Z0-9\\-]+|\\-).*"
         ],
         "url": "https://www.documentcloud.org/documents/{1}-{2}.html",
         "endpoint": "https://www.documentcloud.org/api/oembed.json"

--- a/lib/plugins/system/oembed/providers.json
+++ b/lib/plugins/system/oembed/providers.json
@@ -747,5 +747,13 @@
             "mybeweeg.com/.*"
         ],
         "endpoint": "https://mybeweeg.com/services/oembed"
+    },
+    {
+        "name": "Documentcloud",
+        "templates": [
+            "documentcloud.org/documents/(\\d+)\\-([^%.]+|\\-).*"
+        ],
+        "url": "https://www.documentcloud.org/documents/{1}-{2}.html",
+        "endpoint": "https://www.documentcloud.org/api/oembed.json"
     }
 ]

--- a/lib/plugins/system/oembed/providers.json
+++ b/lib/plugins/system/oembed/providers.json
@@ -749,9 +749,18 @@
         "endpoint": "https://mybeweeg.com/services/oembed"
     },
     {
+        "name": "Documentcloud no .html",
+        "templates": [
+            "documentcloud.org/documents/(\\d+)(-)(?:[^./]+)?"
+        ],
+        "url": "https://www.documentcloud.org/documents/{1}--{2}.html",
+        "endpoint": "https://www.documentcloud.org/api/oembed.json"
+    },
+    {
         "name": "Documentcloud",
         "templates": [
-            "documentcloud.org/documents/(\\d+)-(?:[^./]+)?([./].+)"
+            "documentcloud.org/documents/(\\d+)-(?:[^./]+)?(/[^.]+\\.html.*)",
+            "documentcloud.org/documents/(\\d+)-(?:[^./]+)?(\\.html.*)"
         ],
         "url": "https://www.documentcloud.org/documents/{1}--{2}",
         "endpoint": "https://www.documentcloud.org/api/oembed.json"

--- a/lib/plugins/system/oembed/providers.json
+++ b/lib/plugins/system/oembed/providers.json
@@ -747,22 +747,5 @@
             "mybeweeg.com/.*"
         ],
         "endpoint": "https://mybeweeg.com/services/oembed"
-    },
-    {
-        "name": "Documentcloud",
-        "templates": [
-            "documentcloud.org/documents/(\\d+)-(?:[^./]+)?(/[^.]+\\.html.*)",
-            "documentcloud.org/documents/(\\d+)-(?:[^./]+)?(\\.html.*)"
-        ],
-        "url": "https://www.documentcloud.org/documents/{1}--{2}",
-        "endpoint": "https://www.documentcloud.org/api/oembed.json"
-    },
-    {
-        "name": "Documentcloud no .html",
-        "templates": [
-            "documentcloud.org/documents/(\\d+)(-)(?:[^./]+)?$"
-        ],
-        "url": "https://www.documentcloud.org/documents/{1}-{2}.html",
-        "endpoint": "https://www.documentcloud.org/api/oembed.json"
     }
 ]

--- a/lib/plugins/system/oembed/providers.json
+++ b/lib/plugins/system/oembed/providers.json
@@ -749,20 +749,20 @@
         "endpoint": "https://mybeweeg.com/services/oembed"
     },
     {
-        "name": "Documentcloud no .html",
-        "templates": [
-            "documentcloud.org/documents/(\\d+)(-)(?:[^./]+)?"
-        ],
-        "url": "https://www.documentcloud.org/documents/{1}--{2}.html",
-        "endpoint": "https://www.documentcloud.org/api/oembed.json"
-    },
-    {
         "name": "Documentcloud",
         "templates": [
             "documentcloud.org/documents/(\\d+)-(?:[^./]+)?(/[^.]+\\.html.*)",
             "documentcloud.org/documents/(\\d+)-(?:[^./]+)?(\\.html.*)"
         ],
         "url": "https://www.documentcloud.org/documents/{1}--{2}",
+        "endpoint": "https://www.documentcloud.org/api/oembed.json"
+    },
+    {
+        "name": "Documentcloud no .html",
+        "templates": [
+            "documentcloud.org/documents/(\\d+)(-)(?:[^./]+)?$"
+        ],
+        "url": "https://www.documentcloud.org/documents/{1}-{2}.html",
         "endpoint": "https://www.documentcloud.org/api/oembed.json"
     }
 ]

--- a/plugins/domains/documentcloud.org.js
+++ b/plugins/domains/documentcloud.org.js
@@ -69,6 +69,8 @@ module.exports = {
         'https://www.documentcloud.org/documents/5766398-ASRS-Reports-for-737-max8/annotations/486265.html',
         'https://www.documentcloud.org/documents/5766398-ASRS-Reports-for-737-max8/pages/2.html',
         'https://www.documentcloud.org/documents/7203159-Joaqu%C3%ADn-El-Chapo-Guzm%C3%A1n-Appeal.html',
+        'https://www.documentcloud.org/documents/7203159-Joaqu%C3%ADn-El-Chapo-Guzm%C3%A1n-Appeal',
+        'https://www.documentcloud.org/documents/7203159-Joaqu%C3%ADn-El-Chapo-Guzmán-Appeal/pages/2.html',
         {
             noFeeds: true
         }

--- a/plugins/domains/documentcloud.org.js
+++ b/plugins/domains/documentcloud.org.js
@@ -70,7 +70,7 @@ module.exports = {
         'https://www.documentcloud.org/documents/5766398-ASRS-Reports-for-737-max8/pages/2.html',
         'https://www.documentcloud.org/documents/7203159-Joaqu%C3%ADn-El-Chapo-Guzm%C3%A1n-Appeal.html',
         'https://www.documentcloud.org/documents/7203159-Joaqu%C3%ADn-El-Chapo-Guzm%C3%A1n-Appeal',
-        'https://www.documentcloud.org/documents/7203159-Joaqu%C3%ADn-El-Chapo-Guzmán-Appeal/pages/2.html',
+        'https://www.documentcloud.org/documents/7203159-Joaqu%C3%ADn-El-Chapo-Guzm%C3%A1n-Appeal/pages/2.html',
         {
             noFeeds: true
         }

--- a/plugins/domains/documentcloud.org.js
+++ b/plugins/domains/documentcloud.org.js
@@ -61,31 +61,16 @@ module.exports = {
         } else if (url.indexOf('%') !== -1) {
 
             /** Fix for unicode characters in url causes 400 at provider oEmbed api */
-            var oembedUrl = '';
-            var match1 = url.match(/documentcloud.org\/documents\/(\d+)-(?:[^./]+)?(\/[^.]+\.html.*)/i);
-            var match2 = url.match(/documentcloud.org\/documents\/(\d+)-(?:[^./]+)?(\.html.*)/i);
-            var nohtml = url.match(/documentcloud.org\/documents\/(\d+)(-)(?:[^./]+)?$/i);
-            if (match1 && match1.length === 3) {
-                oembedUrl = `${match1[1]}--${match1[2]}`;
-            } else if (match2 && match2.length === 3) {
-                oembedUrl = `${match2[1]}--${match2[2]}`;
-            } else if (nohtml && nohtml.length === 3) {
-                oembedUrl = `${nohtml[1]}-${nohtml[2]}.html`;
-            }
-            if (oembedUrl) {
-                var uri = encodeURI(`https://www.documentcloud.org/documents/${oembedUrl}`);
-                cb(null, {
-                    oembedLinks: ['json', 'xml'].map(function (format) {
-                        return {
-                            href: `https://www.documentcloud.org/api/oembed.${format}?url=${uri}`,
-                            rel: 'alternate',
-                            type: `application/${format}+oembed`
-                        }
-                    })
+            var uri = encodeURI(url.replace(/(\d+\-)[^./#?]+/i, '$1-').replace(/(\/\d+--)[^.]*$/i, '$1.html'));
+            cb(null, {
+                oembedLinks: ['json', 'xml'].map(function (format) {
+                    return {
+                        href: `https://www.documentcloud.org/api/oembed.${format}?url=${uri}`,
+                        rel: 'alternate',
+                        type: `application/${format}+oembed`
+                    }
                 })
-            } else {
-                cb (null);
-            }
+            })
 
         } else {
             cb (null);

--- a/plugins/domains/documentcloud.org.js
+++ b/plugins/domains/documentcloud.org.js
@@ -68,6 +68,7 @@ module.exports = {
         'https://www.documentcloud.org/documents/5766398-ASRS-Reports-for-737-max8.html#document/p2/a486265',
         'https://www.documentcloud.org/documents/5766398-ASRS-Reports-for-737-max8/annotations/486265.html',
         'https://www.documentcloud.org/documents/5766398-ASRS-Reports-for-737-max8/pages/2.html',
+        'https://www.documentcloud.org/documents/7203159-Joaqu%C3%ADn-El-Chapo-Guzm%C3%A1n-Appeal.html',
         {
             noFeeds: true
         }


### PR DESCRIPTION
Fix for DocumentCloud url with unicode characters causes 400 in oEmbed API