### PR TITLE
encoding: do not use iconv if Node support the charset encoding

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -357,12 +357,23 @@ exports.getCharset = function(string, doNotParse) {
     return charset;
 };
 
-exports.encodeText = function(charset, text) {
+exports.encodeText = function(charset, text) { 
     try {
-        var b = iconv.encode(text, "ISO8859-1");
-        text = iconv.decode(b, charset || "UTF-8");
+        var charset = charset || 'UTF-8';
+
+        if (/* v > 0.9 */ Buffer.isEncoding
+            && Buffer.isEncoding(charset)) {
+            var b = Buffer.from(text, 'binary');
+            text = b.toString(charset);
+        } else {
+            var b = iconv.encode(text, "ISO8859-1");
+            text = iconv.decode(b, charset);
+            
+        }
+
         // Remove 'REPLACEMENT CHARACTER'.
         text = text.replace(/\uFFFD$/ig, '');
+
         return text;
     } catch(e) {
         return text;


### PR DESCRIPTION
For example, most sites with use UTF-8 encoding and will start being handled w/o ICONV