### PR TITLE
Add missing feature policies

### DIFF
--- a/config.js
+++ b/config.js
@@ -165,8 +165,9 @@
 
         FEATURES: [ // feature policy: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#Directives
             'ambient-light-sensor', 'autoplay', 'accelerometer', 'camera', 'display-capture', 'document-domain', 'encrypted-media', 
-            'fullscreen', 'geolocation', 'gyroscope', 'magnetometer', 'microphone', 'midi', 'payment', 'picture-in-picture',
-            'speaker', 'sync-xhr', 'usb', 'wake-lock', 'vr', 'xr', 'vr / xr', 'clipboard-write'
+            'speaker', 'sync-xhr', 'usb', 'wake-lock', 'vr', 'xr', 'vr / xr', 'clipboard-write', 'battery', 
+            'execution-while-not-rendered', 'execution-while-out-of-viewport', 'legacy-image-formats', 'oversized-images',
+            'publickey-credentials-get', 'screen-wake-lock', 'web-share', 'xr-spatial-tracking'
         ],
 
         // Option names

--- a/config.js
+++ b/config.js
@@ -165,7 +165,7 @@
 
         FEATURES: [ // feature policy: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#Directives
             'ambient-light-sensor', 'autoplay', 'accelerometer', 'camera', 'display-capture', 'document-domain', 'encrypted-media', 
-            'speaker', 'sync-xhr', 'usb', 'wake-lock', 'vr', 'xr', 'vr / xr', 'clipboard-write', 'battery', 
+            'speaker', 'sync-xhr', 'usb', 'wake-lock', 'vr', 'vr / xr', 'clipboard-write', 'battery', 
             'execution-while-not-rendered', 'execution-while-out-of-viewport', 'legacy-image-formats', 'oversized-images',
             'publickey-credentials-get', 'screen-wake-lock', 'web-share', 'xr-spatial-tracking'
         ],

--- a/config.js
+++ b/config.js
@@ -164,10 +164,11 @@
         },
 
         FEATURES: [ // feature policy: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#Directives
-            'ambient-light-sensor', 'autoplay', 'accelerometer', 'camera', 'display-capture', 'document-domain', 'encrypted-media', 
-            'speaker', 'sync-xhr', 'usb', 'wake-lock', 'vr', 'vr / xr', 'clipboard-write', 'battery', 
-            'execution-while-not-rendered', 'execution-while-out-of-viewport', 'legacy-image-formats', 'oversized-images',
-            'publickey-credentials-get', 'screen-wake-lock', 'web-share', 'xr-spatial-tracking'
+            'accelerometer', 'ambient-light-sensor', 'autoplay', 'battery', 'camera', 'clipboard-write', 'display-capture',
+            'document-domain', 'encrypted-media', 'execution-while-not-rendered', 'execution-while-out-of-viewport', 
+            'fullscreen', 'geolocation', 'gyroscope', 'legacy-image-formats', 'magnetometer', 'microphone', 'midi', 
+            'oversized-images', 'payment', 'picture-in-picture', 'publickey-credentials-get', 'screen-wake-lock',
+            'speaker', 'sync-xhr', 'usb', 'vr', 'vr / xr', 'wake-lock', 'web-share', 'xr-spatial-tracking'
         ],
 
         // Option names


### PR DESCRIPTION
Hello!

Following up here from our support ticket, I've gone through and added most missing feature policies (comparing with [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#directives) and the [W3C](https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md))

A couple of notes:
 - I removed one unused policy, `xr` (the correct one is `xr-spatial-tracking`, and Chrome initially implemented it as `vr`, which is deprecated but I've left in out of catiousness)
 - I have never seen the `vr / xr` feature policy, and can't find information on it. From the format I'm guessing it might be something non-standard you added for your own purposes, so I've left it in
 - I added all feature policies which are in some way "active", i.e. at least behind a feature flag (and `battery` which is currently not working in Chrome due to a bug). Because of this two of them were left out, `layout-animations` and `navigation-override`
 - I took the liberty to alphabetize the array, but that is its own commit so that you can just revert it if you prefer.

Cheers!