### PR TITLE
Return protocol less links and redirect detection during link type validation

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -55,7 +55,7 @@ function doFetch(fetch_func, h1_fetch_func, options) {
                 });
                 abortController.onResponse(stream);
                 stream.status = response.status;
-                if (response.url) { // Set as final destination url if Fetch follows 301/302 re-directs
+                if (response.url && response.url !== uri) { // Set as final destination url if Fetch follows 301/302 re-directs
                     stream.url = response.url;
                 }
                 stream.headers = response.headers.plain();

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -55,6 +55,9 @@ function doFetch(fetch_func, h1_fetch_func, options) {
                 });
                 abortController.onResponse(stream);
                 stream.status = response.status;
+                if (response.url) { // Set as final destination url if Fetch follows 301/302 re-directs
+                    stream.url = response.url;
+                }
                 stream.headers = response.headers.plain();
                 stream.abortController = abortController;
                 stream.h2 = response.httpVersion === '2.0';

--- a/lib/plugins/validators/async/21_checkContentType.js
+++ b/lib/plugins/validators/async/21_checkContentType.js
@@ -120,8 +120,8 @@ export default {
                 }
 
                 if (!link.error && data.type == CONFIG.T.text_html // check and don't allow https -> http redirects for iFrames
-                    && data.href && /^(?:https:)?\/\//.test(link.href) && /^http:\/\//.test(data.href)) {                    
-                    link.href = data.href;
+                    && data.url && /^(?:https:)?\/\//.test(link.href) && /^http:\/\//.test(data.url)) {                    
+                    link.href = data.url;
                     if (link.rel && link.rel.indexOf('ssl') > -1) {
                         link.rel.splice(link.rel.indexOf('ssl'), 1);
                     }

--- a/lib/plugins/validators/async/21_checkContentType.js
+++ b/lib/plugins/validators/async/21_checkContentType.js
@@ -119,11 +119,21 @@ export default {
                     link.error = data.type + ' is not an expected type (' + link.accept.join(',') + ')';
                 }
 
-                if (!link.error && data.type == CONFIG.T.text_html // check and don't allow https -> http redirects for iFrames
-                    && data.url && /^(?:https:)?\/\//.test(link.href) && /^http:\/\//.test(data.url)) {                    
-                    link.href = data.url;
-                    if (link.rel && link.rel.indexOf('ssl') > -1) {
-                        link.rel.splice(link.rel.indexOf('ssl'), 1);
+                if (!link.error && data.type == CONFIG.T.text_html
+                    && data.url !== link.href) {
+
+                    // Catch https -> http redirects for iFrames
+                    if (/^(?:https:)?\/\//.test(link.href) && /^http:\/\//.test(data.url)) {
+                        link.href = data.url;
+                        if (link.rel && link.rel.indexOf(CONFIG.R.ssl) > -1) {
+                            link.rel.splice(link.rel.indexOf(CONFIG.R.ssl), 1);
+                        }
+                    // And vice versa, upgrade to HTTPs on redirect from HTTP
+                    } else if (/^https:\/\//.test(data.url) && /^http:\/\//.test(link.href)) {
+                        link.href = data.url;
+                        if (link.rel && link.rel.indexOf(CONFIG.R.ssl) === -1) {
+                            link.rel.push(CONFIG.R.ssl);
+                        }
                     }
                 }
 

--- a/lib/plugins/validators/sync/00_validateLink.js
+++ b/lib/plugins/validators/sync/00_validateLink.js
@@ -25,7 +25,20 @@ export default {
             }
 
             // Resolve uri, also fixes url escaping.
+            // ATTN: `urlLib.resolve('http://domain1.com', '//domain2.com')` returns 'http://domain2.com/'
+            const isProtocolless = /^\/\//.test(link.href);
+
             link.href = urlLib.resolve(url, link.href);
+
+            const domainRE = /^(?:https?:)?\/\/([^\/]+)\//;
+            // But undo protocol resolution when it forces HTTP or domains do not match.
+            if (isProtocolless && (
+                /^http:\/\//.test(url)
+                || domainRE.test(url) && domainRE.test(link.href)
+                    && url.match(domainRE)[1] !== link.href.match(domainRE)[1]
+                )) {
+                link.href = link.href.replace(/^https?:\/\//, '//');
+            }
         }
 
         if (!link.rel) {

--- a/lib/plugins/validators/sync/00_validateLink.js
+++ b/lib/plugins/validators/sync/00_validateLink.js
@@ -31,11 +31,12 @@ export default {
             link.href = urlLib.resolve(url, link.href);
 
             const domainRE = /^(?:https?:)?\/\/([^\/]+)\//;
+            var urlDomainMatch, linkDomainMatch;
             // But undo protocol resolution when it forces HTTP or domains do not match.
             if (isProtocolless && (
                 /^http:\/\//.test(url)
-                || domainRE.test(url) && domainRE.test(link.href)
-                    && url.match(domainRE)[1] !== link.href.match(domainRE)[1]
+                || ((urlDomainMatch = url.match(domainRE)) && (linkDomainMatch = link.href(domainRE)))
+                    && urlDomainMatch[1] !== linkDomainMatch[1]
                 )) {
                 link.href = link.href.replace(/^https?:\/\//, '//');
             }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -658,10 +658,9 @@ export function getContentType(uriForCache, uriOriginal, options, cb) {
                         return;
                     }
 
-                    // TODO: what is res.request.href ?
-                    // TODO: where used res.headers.location ?
-                    if (res.request && res.request.href && res.headers && res.request.href !== uriOriginal) {
-                        //res.headers.location = res.request.href;
+                    // Final destination url if Fetch follows 301/302 re-directs
+                    if (res.url && res.url !== uriOriginal && res.headers) {
+                        res.headers.location = res.url;
                     }
 
                     finish(error, res.headers);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -617,7 +617,7 @@ export function getContentType(uriForCache, uriOriginal, options, cb) {
                 if (headers['content-security-policy']) data.csp = headers['content-security-policy'];
                 if (headers['access-control-allow-origin']) data.allow_origin = headers['access-control-allow-origin'];
                 if (headers['accept-ranges']) data.accept_ranges = headers['accept-ranges'];
-                if (headers['location'] !== uriOriginal) data.href = headers['location'];  
+                if (headers['url'] && headers['url'] !== uriOriginal) data.url = headers['url'];  
             }
 
             cb(null, data);
@@ -660,7 +660,7 @@ export function getContentType(uriForCache, uriOriginal, options, cb) {
 
                     // Final destination url if Fetch follows 301/302 re-directs
                     if (res.url && res.url !== uriOriginal && res.headers) {
-                        res.headers.location = res.url;
+                        res.headers.url = res.url;
                     }
 
                     finish(error, res.headers);

--- a/plugins/domains/cnn.com.js
+++ b/plugins/domains/cnn.com.js
@@ -17,11 +17,11 @@ export default {
         var path = ((og.video && og.video.url) || og.url).replace (/^https?:\/\/www\.cnn\.com\/videos?(\/#\/video)?\//i, "");
 
         return {
-                href: "//fave.api.cnn.io/v1/fav/?customer=cnn&env=prod&video=" + path,
-                accept: CONFIG.T.text_html,
-                rel: [CONFIG.R.player, CONFIG.R.html5],
-                "aspect-ratio": 416 / 234
-            };
+            href: "//fave.api.cnn.io/v1/fav/?customer=cnn&env=prod&video=" + path,
+            accept: CONFIG.T.text_html,
+            rel: [CONFIG.R.player, CONFIG.R.html5],
+            "aspect-ratio": 416 / 234
+        };
     },
 
     tests: [{

--- a/plugins/domains/ebaumsworld.com.js
+++ b/plugins/domains/ebaumsworld.com.js
@@ -9,11 +9,11 @@ export default {
 
     getLink: function(urlMatch) {
 
-        //http://www.ebaumsworld.com/media/embed/81387150
+        // https://www.ebaumsworld.com/media/embed/81387150
         return {
-            href: "//www.ebaumsworld.com/media/embed/" + urlMatch[1],
-            type: CONFIG.T.text_html, // validation will timeout
-            rel: [CONFIG.R.player, CONFIG.R.html5],
+            href: "https://www.ebaumsworld.com/media/embed/" + urlMatch[1],
+            accept: CONFIG.T.text_html,
+            rel: [CONFIG.R.player, CONFIG.R.autoplay, CONFIG.R.html5],
             "aspect-ratio": 567 / 345
         };
     },


### PR DESCRIPTION
-  In node 16, `urlLib.resolve('http://domain1.com', '//domain2.com')` returns `'http://domain2.com/'`. This ruins all protocol less link `href`s by resolving them to whatever protocol URL is using.
- Also re-instating the protocol detection when redirecting on link during its type validation. This upgrades URLs to https if they were http.