### PR TITLE
Allow to skip plugin methods with optional errors

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -134,11 +134,12 @@
 
                 var absentParams = _.difference(params, loadedParams);
 
-                // If "__" super mandatory params are absent - skip plugin.
+                // If "__" (as in "__statusCode") or "...Error" (as in "oembedError") 
+                // super mandatory params are absent - skip the plugin.
                 var hasMandatoryParams = false;
                 for(var j = 0; j < absentParams.length && !hasMandatoryParams; j++) {
                     var param = absentParams[j];
-                    if (param.substr(0, 2) === "__") {
+                    if (param.substr(0, 2) === "__" || /error$/i.test(param)) {
                         hasMandatoryParams = true;
                     }
                 }


### PR DESCRIPTION
Parameters ending in "...Error" (as in `oembedError`) are now required. Until they are calculated and set, other method's argument are not initiated. 

Previously, only parameters starting with `__` were required).