### PR TITLE
Try to upgrade all text_html and audio/video links to https

### DIFF
--- a/lib/plugins/validators/async/21_checkContentType.js
+++ b/lib/plugins/validators/async/21_checkContentType.js
@@ -109,7 +109,6 @@ export default {
 
                 /** accept-ranges is misconfigured in many cases (especially via CloudFront). Plus, browsers would try and download first range of MP4 file anyway, even if the header isn't set
                 if (data.type == CONFIG.T.video_mp4 && !/bytes/i.test(data.accept_ranges)) {
-                    console.log('data', data);
                     link.error = 'MP4s should allow partial download via accept ranges';
                 } */
 
@@ -121,8 +120,7 @@ export default {
                     link.error = data.type + ' is not an expected type (' + link.accept.join(',') + ')';
                 }
 
-                if (!link.error && data.type == CONFIG.T.text_html
-                    && data.url !== link.href) {
+                if (!link.error && data.url !== link.href) {
 
                     // Catch https -> http redirects for iFrames
                     if (/^(?:https:)?\/\//.test(link.href) && /^http:\/\//.test(data.url)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -725,16 +725,9 @@ export function getContentType(uriForCache, uriOriginal, options, cb) {
 
         function makeCall(uri, method) {
 
-            // Let's try to upgrade HTTP URLs to HTTPs. 
-            // If the upgrade doen't work, repeat with the original `uri`.
-            var httpsUri; 
-            if (!uri && /^http:\/\//.test(uriOriginal)) {
-                httpsUri = uriOriginal.replace(/^http:\/\//, 'https://');
-            }
-
             var methodCaller = method && method === 'GET' ? getUrlFunctional : getHeadFunctional;
 
-            methodCaller(uri || httpsUri || uriOriginal, {
+            methodCaller(uri, {
                 timeout: options.timeout || CONFIG.RESPONSE_TIMEOUT
             }, {
                 onResponse: function(res) {
@@ -743,7 +736,7 @@ export function getContentType(uriForCache, uriOriginal, options, cb) {
 
                     var error = res.status && res.status != 200 ? res.status : null;
 
-                    if (!method
+                    if (method !== 'GET'
                         // If method HEAD is not allowed. ex. Amazon S3 (=403)
                         // Try call with GET.
                         && (error === 405 
@@ -762,15 +755,16 @@ export function getContentType(uriForCache, uriOriginal, options, cb) {
                         res.headers.url = res.url;
 
                     // If we changed the URL to HTTPs ourselves
-                    } else if (httpsUri && res.headers) {
+                    } else if (uri !== uriOriginal && res.headers) {
                         res.headers.url = httpsUri;
                     }
 
                     finish(error, res.headers);
                 },
+
                 onError: function(error) {
 
-                    if (httpsUri) {
+                    if (uri !== uriOriginal) {
                         makeCall(uriOriginal, 'HEAD');
                         return;
                     }
@@ -779,8 +773,15 @@ export function getContentType(uriForCache, uriOriginal, options, cb) {
             });
         }
 
+        // Let's try to upgrade HTTP URLs to HTTPs. 
+        // If the upgrade doen't work, repeat with the original `uri`.
+        var httpsUri; 
+        if (/^http:\/\//.test(uriOriginal)) {
+            httpsUri = uriOriginal.replace(/^http:\/\//, 'https://');
+        }
+
         // Call HEAD.
-        makeCall();
+        makeCall(httpsUri || uriOriginal, 'HEAD');
 
     }, {
         // Ignore proxy.cache_ttl, if options.cache_ttl === 0 - do not read from cache.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -723,11 +723,18 @@ export function getContentType(uriForCache, uriOriginal, options, cb) {
             totalTime = createTimer();
         }
 
-        function makeCall(method) {
+        function makeCall(uri, method) {
+
+            // Let's try to upgrade HTTP URLs to HTTPs. 
+            // If the upgrade doen't work, repeat with the original `uri`.
+            var httpsUri; 
+            if (!uri && /^http:\/\//.test(uriOriginal)) {
+                httpsUri = uriOriginal.replace(/^http:\/\//, 'https://');
+            }
 
             var methodCaller = method && method === 'GET' ? getUrlFunctional : getHeadFunctional;
 
-            methodCaller(uriOriginal, {
+            methodCaller(uri || httpsUri || uriOriginal, {
                 timeout: options.timeout || CONFIG.RESPONSE_TIMEOUT
             }, {
                 onResponse: function(res) {
@@ -746,18 +753,27 @@ export function getContentType(uriForCache, uriOriginal, options, cb) {
                             // Or ClourFront that gobbles up headers when checking CORS.
                             || (res.headers && !res.headers['access-control-allow-origin']
                                 && res.headers['server'] === 'AmazonS3' && !error ))) {
-                        makeCall('GET');
+                        makeCall(uriOriginal, 'GET');
                         return;
                     }
 
                     // Final destination url if Fetch follows 301/302 re-directs
                     if (res.url && res.url !== uriOriginal && res.headers) {
                         res.headers.url = res.url;
+
+                    // If we changed the URL to HTTPs ourselves
+                    } else if (httpsUri && res.headers) {
+                        res.headers.url = httpsUri;
                     }
 
                     finish(error, res.headers);
                 },
                 onError: function(error) {
+
+                    if (httpsUri) {
+                        makeCall(uriOriginal, 'HEAD');
+                        return;
+                    }
                     finish(error);
                 }
             });


### PR DESCRIPTION
This PR changes http to https for all non-image links during content type validation. 

It works this way:
* If there's see `http://` in link's `href`, the validator tries to fetch `https` instead.
* If successful, `https` is then assigned to link and returned in response.
* If fetching `https://` fails, the validator retries it with the original `http://` URL and default validation flow.