### PR TITLE
Opinary is in process of switching domain, prepare template for it.

### DIFF
--- a/lib/plugins/system/oembed/providers.json
+++ b/lib/plugins/system/oembed/providers.json
@@ -832,7 +832,8 @@
     {
         "name": "Opinary",
         "templates": [
-            "compass.pressekompass.net/*" 
+            "compass.pressekompass.net/*",
+            "midgard.opinary.com/*",
         ],
         "endpoint": "https://api.opinary.com/oembed"
     },


### PR DESCRIPTION
Opinary is switching from compass.pressekompass.net to midgard.opinary.com

In order to do so, we need to support both domains for a period of time, until we later turn of compass.pressekompass.net