### PR TITLE
Allow to configure maxredirects for specific domains

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1533,7 +1533,7 @@
 
         generateProviderOptionsFunc(uri, options);
 
-        if (options.redirectsCount && options.redirectsCount > CONFIG.MAX_REDIRECTS) {
+        if (options.redirectsCount && options.redirectsCount > (options.maxRedirects || CONFIG.MAX_REDIRECTS)) {
             callbackWithErrorCode('redirect loop', options, cb);
             return;
         }

--- a/lib/plugins/system/htmlparser/htmlparser.js
+++ b/lib/plugins/system/htmlparser/htmlparser.js
@@ -122,7 +122,7 @@ export default {
                         const preventCache = redirectUrl === url;
                         options.jar = extendCookiesJar(options.jar, headers);
                         // TODO: do not cache when has unique cookie???
-                        if (options2.maxRedirects) {
+                        if (options2.maxRedirects && (!options.redirectsHistory || options.redirectsHistory.length === 0)) {
                             options.maxRedirects = options2.maxRedirects; // Maybe set in prepareRequestOptions for a proxy.
                         }
                         return cacheAndRespond({

--- a/lib/plugins/system/htmlparser/htmlparser.js
+++ b/lib/plugins/system/htmlparser/htmlparser.js
@@ -18,10 +18,12 @@ export default {
 
     getData: function(url, whitelistRecord, options, __noCachedHtmlparserFallback, cb) {
 
-        getUrlFunctional(url, {...options, ...{
+        var options2 = {...options, ...{
             followRedirect: !!options.followHTTPRedirect,
             reuseCookies: !!options.followHTTPRedirect
-        }}, {
+        }};
+
+        getUrlFunctional(url, options2, {
             onError: function(error) {
                 if (error.code === 'ENOTFOUND') {
                     if (!!options.exposeStatusCode) {
@@ -120,6 +122,9 @@ export default {
                         const preventCache = redirectUrl === url;
                         options.jar = extendCookiesJar(options.jar, headers);
                         // TODO: do not cache when has unique cookie???
+                        if (options2.maxRedirects) {
+                            options.maxRedirects = options2.maxRedirects; // Maybe set in prepareRequestOptions for a proxy.
+                        }
                         return cacheAndRespond({
                             redirect: headers.location
                         }, null, preventCache);                        

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -109,6 +109,9 @@ export function prepareRequestOptions(request_options, options) {
             if (proxy.disable_language) {
                 disable_language = true;
             }
+            if (proxy.maxredirects && (!options.redirectsHistory || options.redirectsHistory.length === 0)) {
+                options.maxRedirects = proxy.maxredirects;
+            }
         }
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -109,7 +109,7 @@ export function prepareRequestOptions(request_options, options) {
             if (proxy.disable_language) {
                 disable_language = true;
             }
-            if (proxy.maxredirects && (!options.redirectsHistory || options.redirectsHistory.length === 0)) {
+            if (options && proxy.maxredirects && (!options.redirectsHistory || options.redirectsHistory.length === 0)) {
                 options.maxRedirects = proxy.maxredirects;
             }
         }


### PR DESCRIPTION
Configuration is done via `PROXY` `maxredirects` attribute. It is marked in `prepareRequestOptions` for initial URL and is copied into main `options` during first redirect.