### PR TITLE
Fix docker vulnerabilites by upgrading node image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17.8-alpine3.15
+FROM node:22.5.1-slim
 
 EXPOSE 8061
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:22.5.1-slim
+FROM node:22-alpine
 
 EXPOSE 8061
 
 WORKDIR /iframely
 
 # Create new non-root user
-RUN addgroup -S iframelygroup && adduser -S iframely -G iframelygroup
+RUN addgroup --system iframelygroup && adduser --system iframely -G iframelygroup
 RUN apk add g++ make python3
 
 # This will change the config to `config.<VALUE>.js` and the express server to change its behaviour.

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ PUBLISHPORT := ${EXPOSEPORT}
 
 build:
 	git checkout main 
-	git pull --rebase upstream main
 	git branch -f tag-${VERSION}
 	git checkout tag-${VERSION}
 	docker \


### PR DESCRIPTION
The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-ALPINE315-ZLIB-2976173
- https://snyk.io/vuln/SNYK-ALPINE315-OPENSSL-3314621
- https://snyk.io/vuln/SNYK-ALPINE315-OPENSSL-3314622
- https://snyk.io/vuln/SNYK-ALPINE315-OPENSSL-3314629
- https://snyk.io/vuln/SNYK-ALPINE315-OPENSSL-3368753

Co-authored-by: snyk-bot <snyk-bot@snyk.io>

Also removed my circular dependency of commits from the Makefile used for building docker.