### PR TITLE
Add missing comma in config local

### DIFF
--- a/config.local.js.SAMPLE
+++ b/config.local.js.SAMPLE
@@ -256,7 +256,7 @@ export default {
         youtube: {
             // api_key: "INSERT YOUR VALUE",
             // parts: [ "snippet", "player" ], // list of fields you want to use in the request, in most cases you only need those two
-            get_params: "?rel=0&showinfo=1"     // https://developers.google.com/youtube/player_parameters,
+            get_params: "?rel=0&showinfo=1",     // https://developers.google.com/youtube/player_parameters,
             fix_shorts_in_eu: true              // Avoid consent redirect for EU servers
         },
         vimeo: {

--- a/modules/api/views.js
+++ b/modules/api/views.js
@@ -133,7 +133,7 @@ export default function(app) {
                     debug: getBooleanParam(req, 'debug'),
                     returnProviderOptionsUsage: getBooleanParam(req, 'debug'),
                     mixAllWithDomainPlugin: getBooleanParam(req, 'mixAllWithDomainPlugin'),
-                    forceParams: req.query.meta === "true" ? ["meta", "oembed"] : null,
+                    forceParams: req.query.meta === "true" ? CONFIG.DEBUG_CONTEXTS : null,
                     whitelist: getBooleanParam(req, 'whitelist'),
                     readability: getBooleanParam(req, 'readability'),
                     getWhitelistRecord: whitelist.findWhitelistRecordFor,


### PR DESCRIPTION
I had the issue that when I started iframely locally with docker (after renaming  `config.local.js.SAMPLE` to `config.local.js` , I would get an error that `fix_shorts_in_eu` from the `config.local.js` (priorly `config.local.js.SAMPLE`) is an unknown symbol and it turns out there was a comma missing. 

This PR adds the missing comma. 

I branched out from main, not sure whether that was a mistake^