### PR TITLE
domains: fix private Soundcloud

### DIFF
--- a/lib/plugins/system/oembed/oembed.js
+++ b/lib/plugins/system/oembed/oembed.js
@@ -31,51 +31,60 @@ function fixOembedIframeAttributes(obj) {
 }
 
 function _getOembedIframe(oembed) {
-    if (!oembed.html) {
-        return null;
-    }
+
     if (typeof oembed._iframe === 'undefined') {
 
-        // Allow encoded entities if they start from $lt;
-        var html = oembed.html5 || oembed.html; 
-        if (/^&lt;$/i.test(html)) {
-            html = entities.decodeHTML(html);
+        var _iframe = null;
+        
+        if (oembed.html5 || oembed.html) {
+
+            // Allow encoded entities if they start from $lt;
+            var html = oembed.html5 || oembed.html; 
+            if (/^&lt;$/i.test(html)) {
+                html = entities.decodeHTML(html);
+            }
+
+            var $container = cheerio('<div>');
+            try {
+                $container.html(html);
+            } catch (ex) {}
+            var $iframe = $container.find('iframe');
+
+            if ($iframe.length === 2 && /<iframe>$/i.test(html)) { 
+                // Forgive mis-closed iFrame tag
+                $iframe = $iframe.first();
+            }
+
+            if ($iframe.length === 1) {
+                _iframe = fixOembedIframeAttributes($iframe[0].attribs);
+                _iframe.placeholder = oembed.thumbnail_url;
+            }
+
+        // When oembed is in fact iframe from domain fallbacks on oEmbedError
+        } else if (oembed.src) {
+            _iframe = oembed;
         }
 
-        var $container = cheerio('<div>');
-        try {
-            $container.html(html);
-        } catch (ex) {}
-        var $iframe = $container.find('iframe');
-
-        if ($iframe.length === 2 && /<iframe>$/i.test(html)) { 
-            // Forgive mis-closed iFrame tag
-            $iframe = $iframe.first();
-        }
-
-        if ($iframe.length === 1) {
-            oembed._iframe = fixOembedIframeAttributes($iframe[0].attribs);
-
-            if (oembed._iframe && oembed._iframe.src) {
-                var src = URL.parse(oembed._iframe.src, true);
-                oembed._iframe.host = src.host;
-                oembed._iframe.pathname = src.pathname;
-                oembed._iframe.path = src.path;
-                oembed._iframe.query = src.query;
-                oembed._iframe.placeholder = oembed.thumbnail_url;
-                oembed._iframe.replaceQuerystring = function(params) {
-                    var qs = querystring.stringify({...oembed._iframe.query, ...params});
-                    return oembed._iframe.src.replace(/\?.*$/, '') + (qs ? '?' + qs : '');
-                }
-                oembed._iframe.assignQuerystring = function(params) {
-                    var qs = querystring.stringify(params);
-                    return oembed._iframe.src.replace(/\?.*$/, '') + (qs ? '?' + qs : '');
-                }                
+        if (_iframe && _iframe.src) {
+            var src = URL.parse(_iframe.src, true);
+            _iframe.host = src.host;
+            _iframe.pathname = src.pathname;
+            _iframe.path = src.path;
+            _iframe.query = src.query;
+            _iframe.replaceQuerystring = function(params) {
+                var qs = querystring.stringify({..._iframe.query, ...params});
+                return _iframe.src.replace(/\?.*$/, '') + (qs ? '?' + qs : '');
+            }
+            _iframe.assignQuerystring = function(params) {
+                var qs = querystring.stringify(params);
+                return oembed._iframe.src.replace(/\?.*$/, '') + (qs ? '?' + qs : '');
             }
         } else {
-            oembed._iframe = null;
+            _iframe = null;
         }
-    }
+
+        oembed._iframe = {..._iframe};
+    }    
 
     return oembed._iframe;
 }
@@ -98,6 +107,8 @@ function getOembedIframeAttr(oembed) {
 export default {
 
     provides: ['self', 'oembedError'],
+
+    getIframe: _getOembedIframe, // available via export for fallbacks as plugins['oembed'].getIframe(obj)
 
     getData: function(url, oembedLinks, options, cb) {
 

--- a/plugins/domains/soundcloud.com/soundcloud-oembed-error.js
+++ b/plugins/domains/soundcloud.com/soundcloud-oembed-error.js
@@ -2,17 +2,18 @@ export default {
 
     provides: ['__allow_soundcloud_meta', 'iframe'],
 
-    getData: function(oembedError, twitter, options, cb) {
-        if (oembedError === 403 && !options.getProviderOptions('soundcloud.disable_private', false) && twitter.player) {
+    getData: function(oembedError, twitter, options, plugins, cb) {
+        var disable_private = options.getProviderOptions('soundcloud.disable_private', false)
+        if (oembedError === 403 && !disable_private && twitter.player) {
             return cb(null, {
                 __allow_soundcloud_meta: true,
-                iframe: {
-                    src: twitter.player.value,
+                iframe: plugins['oembed'].getIframe({
+                    src: twitter.player.value?.replace('origin=twitter', 'origin=iframely'),
                     height: twitter.player.height
-                },
+                }),
                 message: "Contact support to disable private Soundcloud audio."
             });
-        } else if (oembedError === 403 && options.getProviderOptions('soundcloud.disable_private', false)) {
+        } else if (oembedError === 403 && disable_private) {
             return cb({
                 responseError: oembedError
             });


### PR DESCRIPTION
Private SoundCloud works as the fallback to main Soundcloud plugin that expects full `oembed`/ `iframe` object with  `assignQuerystring` method and others.

This fix exposes the method to create such `iframe` object from a simple JSON fallback.