### PR TITLE
Validate M3U8 CORS taking into account requested origin

### DIFF
--- a/lib/plugins/validators/async/21_checkContentType.js
+++ b/lib/plugins/validators/async/21_checkContentType.js
@@ -122,7 +122,9 @@ export default {
                     link.error = 'MP4s should allow partial download via accept ranges';
                 } */
 
-                if ((data.type == CONFIG.T.stream_apple_mpegurl || data.type == CONFIG.T.stream_x_mpegurl) && data.allow_origin !== '*') {
+                if ((data.type == CONFIG.T.stream_apple_mpegurl || data.type == CONFIG.T.stream_x_mpegurl) 
+                    && data.allow_origin !== '*' 
+                    && (!data.request_origin && !data.allow_origin || data.allow_origin.indexOf(data.request_origin) == -1)) {
                     link.error = 'CORS headers on the player are not configured correctly';
                 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -236,7 +236,7 @@ export function prepareRequestOptions(request_options, options) {
                 if (!options.asBuffer) {
                     stream.setEncoding("binary");
                 }
-                callbacks.onResponse && callbacks.onResponse(stream);
+                callbacks.onResponse && callbacks.onResponse(stream, request_options);
             })
             .catch(error => {
                 callbacks.onError && callbacks.onError(error);
@@ -282,7 +282,7 @@ var getHead = function(url, options, callbacks) {
     try {
         fetchStreamAuthorized(request_options)
             .then(response => {
-                callbacks.onResponse && callbacks.onResponse(response);
+                callbacks.onResponse && callbacks.onResponse(response, request_options);
             })
             .catch(error => {
                 callbacks.onError && callbacks.onError(error);
@@ -779,6 +779,7 @@ export function getContentType(uriForCache, uriOriginal, options, cb) {
                 if (headers['x-frame-options']) data.x_frame_options = headers['x-frame-options'];
                 if (headers['content-security-policy']) data.csp = headers['content-security-policy'];
                 if (headers['access-control-allow-origin']) data.allow_origin = headers['access-control-allow-origin'];
+                if (headers.request_headers?.origin) data.request_origin = headers.request_headers.origin;
                 if (headers['accept-ranges']) data.accept_ranges = headers['accept-ranges'];
                 if (headers['url'] && headers['url'] !== uriOriginal) data.url = headers['url'];
 
@@ -805,7 +806,7 @@ export function getContentType(uriForCache, uriOriginal, options, cb) {
             methodCaller(uri, {
                 timeout: options.timeout || CONFIG.RESPONSE_TIMEOUT
             }, {
-                onResponse: function(res) {
+                onResponse: function(res, request_options) {
 
                     abortController = res.abortController;
 
@@ -833,6 +834,10 @@ export function getContentType(uriForCache, uriOriginal, options, cb) {
                     // If we changed the URL to HTTPs ourselves
                     } else if (uri !== uriOriginal && res.headers) {
                         res.headers.url = uri;
+                    }
+
+                    if (request_options?.headers && res.headers) {
+                        res.headers.request_headers = Object.fromEntries(Object.entries(request_options.headers).map(([k, v]) => [k.toLowerCase(), v]));
                     }
 
                     finish(error, res.headers);


### PR DESCRIPTION
If we request validation with `origin: https://iframely.com`, allow m3u8 when provider replies with`'access-control-allow-origin': 'https://iframely.com'`. Ex.: Apple TV.