### PR TITLE
Add thoughtsandprayersthegame.com plugin

### DIFF
--- a/plugins/domains/thoughtsandprayersthegame.com.js
+++ b/plugins/domains/thoughtsandprayersthegame.com.js
@@ -1,0 +1,24 @@
+export default {
+
+    re: /^https?:\/\/(?:www\.)?thoughtsandprayersthegame\.com\/?$/i,
+
+    mixins: [
+        "*"
+    ],
+
+    getLink: function() {
+        return {
+            href: "https://thoughtsandprayersthegame.com/embed.html",
+            rel: [CONFIG.R.app, CONFIG.R.iframely],
+            type: CONFIG.T.text_html,
+            "aspect-ratio": 16/9
+        };
+    },
+
+    tests: [{noFeeds: true}, {skipMethods: ['getData']},
+        "https://thoughtsandprayersthegame.com/",
+        "https://thoughtsandprayersthegame.com",
+        "https://www.thoughtsandprayersthegame.com/"
+    ]
+
+};


### PR DESCRIPTION
## Summary

Adds a domain plugin for [Thoughts & Prayers: The Game](https://thoughtsandprayersthegame.com/), a browser-based game where the player stops mass shootings using the power of thoughts and prayers. The site is a static page that hosts the playable game in an iframe.

## Embed

The site exposes a chrome-less player at `/embed.html` (no header, no footer, just the game) at a 16:9 aspect ratio matching the game canvas. The plugin maps the site's root URL to that player.

The site already exposes:

- `<link rel="iframely player" type="text/html" href="https://thoughtsandprayersthegame.com/embed.html" media="(aspect-ratio: 16/9)">`
- `iframely:title`, `iframely:description`, `iframely:image` meta tags
- oEmbed discovery (`<link rel="alternate" type="application/json+oembed" ...>`) pointing at `/oembed.json`
- Open Graph and Twitter player card meta
- `Content-Security-Policy: frame-ancestors *` (no `X-Frame-Options` blocking)

## Tests

```
https://thoughtsandprayersthegame.com/
https://thoughtsandprayersthegame.com
https://www.thoughtsandprayersthegame.com/
```

All three should resolve to the same `/embed.html` player at 16:9.