### PR TITLE
Meta: use `decodeHTMLStrict` instead of `decodeHTML5`

### DIFF
--- a/lib/plugins/system/meta/HTMLMetaHandler.js
+++ b/lib/plugins/system/meta/HTMLMetaHandler.js
@@ -1,4 +1,4 @@
-import { decodeHTML5 } from 'entities';
+import { decodeHTMLStrict as decodeHTML5 } from 'entities';
 import * as url from 'url';
 import * as utils from '../../../utils.js';
 import { ldParser } from './ld-json.js';

--- a/lib/plugins/system/meta/HTMLMetaHandler.js
+++ b/lib/plugins/system/meta/HTMLMetaHandler.js
@@ -1,4 +1,4 @@
-import { decodeHTMLStrict as decodeHTML5 } from 'entities';
+import { decodeHTMLStrict } from 'entities';
 import * as url from 'url';
 import * as utils from '../../../utils.js';
 import { ldParser } from './ld-json.js';
@@ -57,7 +57,7 @@ HTMLMetaHandler.prototype.onopentag = function(name, attributes) {
         if (tagName) {
 
             if (/&[^;]+;/i.test(tagName)) {
-                tagName = decodeHTML5(tagName);
+                tagName = decodeHTMLStrict(tagName);
             }
             var propertyParts = tagName.split(/(?::|\.)/);
 
@@ -98,7 +98,7 @@ HTMLMetaHandler.prototype.onopentag = function(name, attributes) {
             var refresh = metaTag.content && metaTag.content.match(/url=(?:'|")?([^'"]+)(?:'|")?/i);
 
             if (refresh) { 
-                this._refresh = decodeHTML5(refresh[1]);
+                this._refresh = decodeHTMLStrict(refresh[1]);
             }
 
         } else if (metaTag.name == "description") {
@@ -265,11 +265,11 @@ HTMLMetaHandler.prototype._finalMerge = function(tag) {
                 if (typeof(obj[k]) == 'string'){
                     // decode HTML entities after decoding the charset
                     // otherwise we would end up with a string with mixed encoding
-                    obj[k] = decodeHTML5(encodeText(that._charset, obj[k]));
+                    obj[k] = decodeHTMLStrict(encodeText(that._charset, obj[k]));
 
                     if (k === 'href') {
                         try {
-                            // Process 'href' after decodeHTML5.
+                            // Process 'href' after decodeHTMLStrict.
                             var href = obj[k];
                             href = href.replace(/(\r\n|\n|\r)/gm,"");
                             href = url.resolve(that._uri, href);

--- a/plugins/domains/dailymail.com/dailymail.video.js
+++ b/plugins/domains/dailymail.com/dailymail.video.js
@@ -1,4 +1,4 @@
-import { decodeHTML5 } from 'entities';
+import { decodeHTMLStrict } from 'entities';
 
 export default {
 
@@ -13,15 +13,15 @@ export default {
 
         if ($player.length == 1) {
             return {
-                dailymailVideo: JSON.parse(decodeHTML5($player.attr('data-opts')))
+                dailymailVideo: JSON.parse(decodeHTMLStrict($player.attr('data-opts')))
             }
         }
     },
 
     getMeta: function(dailymailVideo, decode) {
         return {
-            title: decodeHTML5(decode(dailymailVideo.title)),
-            description: decodeHTML5(decode(dailymailVideo.descr))
+            title: decodeHTMLStrict(decode(dailymailVideo.title)),
+            description: decodeHTMLStrict(decode(dailymailVideo.descr))
         }
     },
 

--- a/plugins/domains/google.com/docs.google.com.js
+++ b/plugins/domains/google.com/docs.google.com.js
@@ -1,4 +1,4 @@
-import { decodeHTML5 } from 'entities';
+import { decodeHTMLStrict } from 'entities';
 
 export default {
 
@@ -132,7 +132,7 @@ export default {
 
                 var key = $el.attr('itemprop');
                 if (key) {
-                    var value = decodeHTML5(decode($el.attr('content') || $el.attr('href')));
+                    var value = decodeHTMLStrict(decode($el.attr('content') || $el.attr('href')));
                     result[key] = value;
                 }
             });

--- a/plugins/links/embedURL/embedURL.js
+++ b/plugins/links/embedURL/embedURL.js
@@ -1,4 +1,4 @@
-import { decodeHTML5 } from 'entities';
+import { decodeHTMLStrict } from 'entities';
 
 export default {
 
@@ -55,7 +55,7 @@ export default {
 
                 var key = $el.attr('itemprop');
                 if (key) {
-                    var value = decodeHTML5(decode($el.attr('content') || $el.attr('href')));
+                    var value = decodeHTMLStrict(decode($el.attr('content') || $el.attr('href')));
                     result[key] = value;
                 }
             });

--- a/plugins/meta/description-from-p-tag.js
+++ b/plugins/meta/description-from-p-tag.js
@@ -1,4 +1,4 @@
-import { decodeHTML5 } from 'entities';
+import { decodeHTMLStrict } from 'entities';
 
 export default {
 
@@ -11,7 +11,7 @@ export default {
         cheerio("body p").each(function() {
             var $p = cheerio(this);
             if ($p.children("label, input, button, div, script, span").length === 0 && !$p.parents("noscript, header,#header,[role='banner']").length) {
-                var someText = decodeHTML5(decode($p.text()));
+                var someText = decodeHTMLStrict(decode($p.text()));
                 var requiredLimit = Number.isInteger(__allowPTagDescription) ? __allowPTagDescription : 64;
                 if (someText.length > requiredLimit) {
                     description = someText;


### PR DESCRIPTION
## About the changes

- Bug fix (non-breaking change which fixes an issue)

### What has changed

Please describe what the code is doing (in this repo):

- fix `decodeHTML5` converts `&region` to `®ion`
- replace all `decodeHTML5` with `decodeHTMLStrict`

