### PR TITLE
Fix Docker build: copy patches/ before pnpm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN corepack enable
 
 ## Utilize docker layer cache
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /iframely/
+COPY patches/ /iframely/patches/
 RUN pnpm install --frozen-lockfile --prod
 
 COPY . /iframely


### PR DESCRIPTION
**This had to be moved from #669 by @joltcan  to run the PR integration checks in our staging env.**

Scope

**Category**: Docker

## About the changes

- Bug fix (non-breaking change which fixes an issue)

### What has changed

Docker build was broken due to missing `patches/` directory at install time.

pnpm reads `patchedDependencies` (`readabilitySAX@1.6.1`) at install time, but the `patches/` directory was only copied later via `COPY . /iframely`, causing `ENOENT` and a failed build.

Fixed by adding `COPY patches/ /iframely/patches/` before `pnpm install --frozen-lockfile`, alongside the existing layer-cache copies of `package.json` and `pnpm-lock.yaml`.

### Related PRs in other repos

None

### Checklist

- [x] I have performed a self-review of my code, including Files Changed view
- [x] Fix/feat branches in all related repos are named the same
- [x] All related PRs are submitted
- [ ] Task is DONE and links back to this PR or no task

## Review

Single-line Dockerfile change, no migration steps or release notices required. Low risk.

- [ ] PRs have been tested on staging by DEV
- [ ] PRs have been tested on staging by QA
- [ ] PRs have been tested on staging by PRODUCT