### PR TITLE
Validators: allow `https:` as allow-all `*` value in CSP frame-ancestors check

### DIFF
--- a/lib/plugins/validators/async/21_checkContentType.js
+++ b/lib/plugins/validators/async/21_checkContentType.js
@@ -95,7 +95,7 @@ export default {
 
                     if (frame_ancestors) { // allow only if it contains " * " or "http://*" or "https://*"
                         frame_ancestors = frame_ancestors.replace(/https?:\/\/\*/ig, '*'); // Ex. Behance video streams via Adobe CDN
-                        frame_ancestors = frame_ancestors.replace(/\bhttps?:(?!\S)/ig, '*'); // "https:" alone means any HTTPS origin
+                        frame_ancestors = frame_ancestors.replace(/\bhttps?:(?!\S)/ig, '*'); // Ex. "frame-ancestors https:" - scheme-only means any HTTPS origin
                         frame_ancestors = frame_ancestors.replace(/^\*/i, ' *');
                         frame_ancestors = frame_ancestors.replace(/\*$/i, '* ');
                         if (frame_ancestors.indexOf(' * ') == -1) {

--- a/lib/plugins/validators/async/21_checkContentType.js
+++ b/lib/plugins/validators/async/21_checkContentType.js
@@ -95,6 +95,7 @@ export default {
 
                     if (frame_ancestors) { // allow only if it contains " * " or "http://*" or "https://*"
                         frame_ancestors = frame_ancestors.replace(/https?:\/\/\*/ig, '*'); // Ex. Behance video streams via Adobe CDN
+                        frame_ancestors = frame_ancestors.replace(/\bhttps?:(?!\S)/ig, '*'); // "https:" alone means any HTTPS origin
                         frame_ancestors = frame_ancestors.replace(/^\*/i, ' *');
                         frame_ancestors = frame_ancestors.replace(/\*$/i, '* ');
                         if (frame_ancestors.indexOf(' * ') == -1) {


### PR DESCRIPTION
### What has changed

Please describe what the code is doing (in this repo):

- fix frame-ancestors like "content-security-policy: frame-ancestors https:"
- 
