### PR TITLE
Fix: FB's 404 on valid posts with visibility restrictions

### DIFF
--- a/plugins/domains/facebook.com/facebook.meta-fallback.js
+++ b/plugins/domains/facebook.com/facebook.meta-fallback.js
@@ -9,7 +9,8 @@ export default {
 
     getData: function(url, __statusCode, options, cb) {
 
-        return __statusCode !== 429 && __statusCode !== 403 &&__statusCode !== 508
+        return __statusCode !== 429 && __statusCode !== 403 &&__statusCode !== 508 
+                && __statusCode !== 404 // Real 404s are handled by `fb-error`, the redirects to "/unsupportedbrowser" are likely due to the requirement to be logged in, allowing it.
 
             ? cb({
                 responseStatusCode: __statusCode,
@@ -17,7 +18,7 @@ export default {
 
             : cb(null, {
                 meta: {},
-                message: `Facebook is rate-limiting. Meta disabled.`
+                message: __statusCode !== 404 ? 'Facebook is rate-limiting. Meta disabled.' : 'Post visibility seem restricted. Allowing.'
             })
     }
 };

--- a/plugins/domains/facebook.com/facebook.meta-fallback.js
+++ b/plugins/domains/facebook.com/facebook.meta-fallback.js
@@ -10,7 +10,7 @@ export default {
     getData: function(url, __statusCode, options, cb) {
 
         return __statusCode !== 429 && __statusCode !== 403 &&__statusCode !== 508 
-                && __statusCode !== 404 // Real 404s are handled by `fb-error`, the redirects to "/unsupportedbrowser" are likely due to the requirement to be logged in, allowing it.
+                && !(__statusCode === 404  && options.getProviderOptions('facebook.ignore_http_404', false)) // Real 404s are handled by `fb-error`, the redirects to "/unsupportedbrowser" are likely due to the requirement to be logged in, allowing it.
 
             ? cb({
                 responseStatusCode: __statusCode,


### PR DESCRIPTION

## Demo and staging

**Demo link**: https://www.facebook.com/lina.benredouane/posts/27475728962058054


## About the changes

- Bug fix (non-breaking change which fixes an issue)

### What has changed

- Try and solve false-positive 404s on FB posts that require logged in audience
