### PR TITLE
add livecodes.io plugin

### DIFF
--- a/plugins/domains/livecodes.io.js
+++ b/plugins/domains/livecodes.io.js
@@ -1,13 +1,5 @@
 export default {
-  re: /^https?:\/\/(?:[a-z0-9-]+\.)?livecodes\.io\/(?:index\.html)?(?:\?[^#]*)?(?:#.*)?$/i,
-
-  mixins: [
-    "oembed-title",
-    "oembed-site",
-    "oembed-thumbnail",
-    "oembed-iframe",
-    "domain-icon",
-  ],
+  mixins: ["*"],
 
   getLink: function (oembed, iframe, options) {
     const params = Object.assign({}, iframe.query);

--- a/plugins/domains/livecodes.io.js
+++ b/plugins/domains/livecodes.io.js
@@ -1,0 +1,78 @@
+export default {
+  re: /^https?:\/\/(?:[a-z0-9-]+\.)?livecodes\.io\/(?:index\.html)?(?:\?[^#]*)?(?:#.*)?$/i,
+
+  mixins: [
+    "oembed-title",
+    "oembed-site",
+    "oembed-thumbnail",
+    "oembed-iframe",
+    "domain-icon",
+  ],
+
+  getLink: function (oembed, iframe, options) {
+    const params = Object.assign({}, iframe.query);
+
+    const height = options.getRequestOptions(
+      "livecodes.height",
+      oembed.height || 400,
+    );
+
+    const theme = options.getRequestOptions(
+      "players.theme",
+      params.theme || "auto",
+    );
+
+    if (theme === "auto") {
+      delete params.theme;
+    } else {
+      params.theme = theme;
+    }
+
+    const click_to_load = options.getRequestOptions(
+      "livecodes.click_to_load",
+      params.loading === "click",
+    );
+
+    if (click_to_load) {
+      params.loading = "click";
+    } else {
+      delete params.loading;
+    }
+
+    const href = iframe.assignQuerystring(params);
+
+    return {
+      href,
+      type: CONFIG.T.text_html,
+      rel: [CONFIG.R.app, CONFIG.R.oembed],
+      height,
+      options: {
+        height: {
+          label: CONFIG.L.height,
+          value: height,
+          placeholder: "ex.: 400, in px",
+        },
+        click_to_load: {
+          label: "Use click-to-load",
+          value: click_to_load,
+        },
+        theme: {
+          label: CONFIG.L.theme,
+          value: theme,
+          values: {
+            light: CONFIG.L.light,
+            dark: CONFIG.L.dark,
+            auto: CONFIG.L.default,
+          },
+        },
+      },
+    };
+  },
+
+  tests: [
+    "https://livecodes.io/?template=react",
+    "https://livecodes.io/?x=id/nvpsgtwr6em",
+    "https://livecodes.io/?js=console.log(%27Hello,%20LiveCodes!%27)&console=open",
+    "https://v49.livecodes.io/?template=vue",
+  ],
+};


### PR DESCRIPTION
## Scope

**Category**: N/A (external contribution — new domain plugin)
**Task**: No task — adds a domain plugin for [LiveCodes](https://livecodes.io), a registered oEmbed provider ([oembed.com registry entry](https://github.com/iamcal/oembed/blob/master/providers/LiveCodes.yml))

## Demo and staging

**Demo link**: https://iframely.com/try?url=https%3A%2F%2Flivecodes.io%2F%3Ftemplate%3Dreact

**Screenshot**:

/debug?uri=https%3A%2F%2Flivecodes.io%2F%3Ftemplate%3Dreact:

<img width="1893" height="1387" alt="image" src="https://github.com/user-attachments/assets/c9f2ece7-b21c-433a-a2df-1c1d96613507" />

## About the changes

- [x] New feature (non-breaking change which adds functionality)

### What has changed

Please describe what the code is doing (in this repo):

- Adds `plugins/domains/livecodes.io.js`, a domain plugin for LiveCodes code playgrounds.
- LiveCodes serves oEmbed (JSON, `rich` type) with per-URL discovery tags at `https://livecodes.io/oembed`. The domain is already in the central whitelist (`oembed.rich: allow, horizontal, reader, resizable`), so generic oEmbed works today — this plugin adds embed options on top of it.
- The regex is fully anchored because the playground lives at the root URL: it matches `livecodes.io/` and versioned/permanent-URL subdomains (e.g. `v49.livecodes.io/`) with an optional `index.html`, query string and hash, while deliberately **not** matching other paths such as `/docs/*` or `/blog/*` (regular content pages, no embeds).
- `getLink` takes the iframe extracted from the oEmbed `html` (via the `oembed-iframe` mixin) and exposes three user-facing options:
  - **height** — defaults to the oEmbed `height` (400);
  - **click_to_load** — toggles `loading=click`, LiveCodes' native deferred-loading mode for embeds;
  - **theme** — `light` / `dark` via the `theme` query param, with `auto` (param removed) as default, read through the standard `players.theme` request option.
- Skips `oembed-author` (LiveCodes responses have no author fields) and `description` (not provided).
- All four test URLs are permanent: two are template starters, one is a short share-ID URL backed by the share API, and one targets a versioned subdomain. They are covered by our registry schemes and will remain live.

### Related PRs in other repos

- N/A

### Checklist

- [x] I have performed a self-review of my code, including Files Changed view
- [x] Fix/feat branches in all related repos are named the same (single repo)
- [x] All related PRs are submitted (none required)
- [x] Task is DONE and links back to this PR or no task

## Review

Please note any risks, caveats, migration steps, release notices or additional tasks.

- [ ] PRs have been tested on staging by DEV
- [x] PRs have been tested on staging by QA
- [ ] PRs have been tested on staging by PRODUCT

**Testing done locally** (self-hosted instance from this branch):

- `GET /iframely?url=https://livecodes.io/?template=react` returns the app link, correct href, height, and the three options; theme/height/click_to_load option changes round-trip into the iframe URL as expected.
- Non-playground URLs (`https://livecodes.io/docs/features/embeds`) correctly fall through to generics.
- `theme=dark`, `theme=light` and `loading=click` verified against the live embed URLs.

**Notes for maintainers:**

- [LiveCodes](https://livecodes.io/) is an [open-source](https://github.com/live-codes/livecodes) client-side code playground that supports 90+ languages/frameworks. Projects can be shared and embedded. See [LiveCodes docs](https://livecodes.io/docs/) for details.
- I maintain LiveCodes, so the oEmbed endpoint, the URL params used here, and the test URLs are all under my control and will be kept stable. Embed docs: https://livecodes.io/docs/features/embeds
