### PR TITLE
cache: send `refreshing` to cache if runs with `options.refresh`

### DIFF
--- a/lib/plugins/system/htmlparser/htmlparser.js
+++ b/lib/plugins/system/htmlparser/htmlparser.js
@@ -106,7 +106,7 @@ export default {
 
                         cache.set(key, cachedData, {
                             ttl: ttl,
-                            refreshing: options.refresh
+                            refresh: options.refresh
                         });
                     }
 

--- a/lib/plugins/system/htmlparser/htmlparser.js
+++ b/lib/plugins/system/htmlparser/htmlparser.js
@@ -105,7 +105,8 @@ export default {
                         var key = metaUtils.getMetaCacheKey(url, whitelistRecord, options);
 
                         cache.set(key, cachedData, {
-                            ttl: ttl
+                            ttl: ttl,
+                            refreshing: options.refresh
                         });
                     }
 

--- a/lib/plugins/system/meta/meta.js
+++ b/lib/plugins/system/meta/meta.js
@@ -51,7 +51,7 @@ export default {
                         _sys_headers: htmlparser.headers
                     }, meta), {
                         ttl: ttl,
-                        refreshing: options.refresh
+                        refresh: options.refresh
                     });
 
                     if (options.refresh) {

--- a/lib/plugins/system/meta/meta.js
+++ b/lib/plugins/system/meta/meta.js
@@ -50,7 +50,8 @@ export default {
                         _sys_created_at: Math.floor(new Date().getTime() / 1000),
                         _sys_headers: htmlparser.headers
                     }, meta), {
-                        ttl: ttl
+                        ttl: ttl,
+                        refreshing: options.refresh
                     });
 
                     if (options.refresh) {

--- a/lib/plugins/system/oembed/oembedUtils.js
+++ b/lib/plugins/system/oembed/oembedUtils.js
@@ -277,7 +277,7 @@ export function findOembedLinks(uri, meta) {
                 // Use proxy.cache_ttl or options.cache_ttl.
                 // If options.cache_ttl === 0 and no proxy.cache_ttl, then CONFIG.CACHE_TTL will be used.
                 ttl: utils.getMaxCacheTTL(uri, options),
-                refreshing: options.refresh
+                refresh: options.refresh
             });
         }
 

--- a/lib/plugins/system/oembed/oembedUtils.js
+++ b/lib/plugins/system/oembed/oembedUtils.js
@@ -276,7 +276,8 @@ export function findOembedLinks(uri, meta) {
             cache.set(oembed_key, data, {
                 // Use proxy.cache_ttl or options.cache_ttl.
                 // If options.cache_ttl === 0 and no proxy.cache_ttl, then CONFIG.CACHE_TTL will be used.
-                ttl: utils.getMaxCacheTTL(uri, options)
+                ttl: utils.getMaxCacheTTL(uri, options),
+                refreshing: options.refresh
             });
         }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -131,7 +131,8 @@ export default function(options, iframely_options, callback) {
                         },
                         data: data
                     }, {
-                        ttl: ttl
+                        ttl: ttl,
+                        refreshing: refresh
                     });
 
                     // temp cache migration, set new key as well
@@ -143,7 +144,8 @@ export default function(options, iframely_options, callback) {
                             },
                             data: data
                         }, {
-                            ttl: ttl
+                            ttl: ttl,
+                            refreshing: refresh
                         });
                     }
                 }
@@ -207,7 +209,8 @@ export default function(options, iframely_options, callback) {
     
                 if (new_cache_key) {
                     cache.set('req:' + prefix + new_cache_key, data, {
-                        ttl: ttl
+                        ttl: ttl,
+                        refreshing: refresh
                     });
                 }
     

--- a/lib/request.js
+++ b/lib/request.js
@@ -132,7 +132,7 @@ export default function(options, iframely_options, callback) {
                         data: data
                     }, {
                         ttl: ttl,
-                        refreshing: refresh
+                        refresh: refresh
                     });
 
                     // temp cache migration, set new key as well
@@ -145,7 +145,7 @@ export default function(options, iframely_options, callback) {
                             data: data
                         }, {
                             ttl: ttl,
-                            refreshing: refresh
+                            refresh: refresh
                         });
                     }
                 }
@@ -210,7 +210,7 @@ export default function(options, iframely_options, callback) {
                 if (new_cache_key) {
                     cache.set('req:' + prefix + new_cache_key, data, {
                         ttl: ttl,
-                        refreshing: refresh
+                        refresh: refresh
                     });
                 }
     


### PR DESCRIPTION
## About the changes

- New feature (non-breaking change which adds functionality)

### What has changed

Please describe what the code is doing (in this repo):

- cache: send `refreshing` to cache if runs with `options.refresh` - to identify if old cache need to be cleaned

### Checklist

- [x] I have performed a self-review of my code, including Files Changed view
- [ ] Fix/feat branches in all related repos are named the same
- [x] All related PRs are submitted
- [ ] Task is DONE and links back to this PR or no task

## Review

Please note any risks, caveats, migration steps, release notices or additional tasks.

- [x] PRs have been tested on staging by DEV
- [ ] PRs have been tested on staging by QA
- [ ] PRs have been tested on staging by PRODUCT

*Please describe the tests and give additional instructions if required, add screenshots and links if necessary.*
