### PR TITLE
LD: Keep camelCase field names

### DIFF
--- a/config.js
+++ b/config.js
@@ -406,7 +406,8 @@
             articlebody: 'articleBody',
             datemodified: 'dateModified',
             datepublished: 'datePublished',
-            datecreated: 'dateCreated'
+            datecreated: 'dateCreated',
+            isaccessibleforfree: 'isAccessibleForFree'
         }
     };
 

--- a/config.js
+++ b/config.js
@@ -389,6 +389,24 @@
                 'ImageObject',
                 'Photograph'
             ]
+        },
+
+        // Used to unify field naming
+        LD_FIELD_ALIASES: {
+            articlesection: 'articleSection',
+            pricecurrency: 'priceCurrency',
+            embedurl: 'embedUrl',
+            embedURL: 'embedUrl',
+            thumbnailurl: 'thumbnailUrl',
+            thumbnailURL: 'thumbnailUrl',
+            contenturl: 'contentUrl',
+            contentURL: 'contentUrl',
+            ContentUrl: 'contentUrl', 
+            videoobject: 'videoObject',
+            articlebody: 'articleBody',
+            datemodified: 'dateModified',
+            datepublished: 'datePublished',
+            datecreated: 'dateCreated'
         }
     };
 

--- a/lib/plugins/system/meta/HTMLMetaHandler.js
+++ b/lib/plugins/system/meta/HTMLMetaHandler.js
@@ -386,12 +386,14 @@ HTMLMetaHandler.prototype._finalMerge = function(tag) {
     }, this._uri);
 
     encodeAllStrings(this._result);
-    // return LD if there's one
+    lowerCaseKeys(this._result);
+
+    // do not lowercase LD objects here as the as there is other source of LD
+    // instead, keep camel case and rely on parseLDSource to unify naming for use in plugins
     if (ld) {
         this._result.ld = ld;
     }
 
-    lowerCaseKeys(this._result);
 
     this._result['charset'] = this._charset || 'UTF-8';
 

--- a/lib/plugins/system/meta/HTMLMetaHandler.js
+++ b/lib/plugins/system/meta/HTMLMetaHandler.js
@@ -389,7 +389,7 @@ HTMLMetaHandler.prototype._finalMerge = function(tag) {
     lowerCaseKeys(this._result);
 
     // do not lowercase LD objects here as the as there is other source of LD
-    // instead, keep camel case and rely on parseLDSource to unify naming for use in plugins
+    // instead, keep camel case and rely on parseLDSource inside ldParser to unify naming for use in plugins
     if (ld) {
         this._result.ld = ld;
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -569,8 +569,6 @@ export function parseLDSource(ld, decode, uri, type_aliases) {
         }
     };
 
-    const camelCaseKeys = (key) => CONFIG.LD_FIELD_ALIASES && CONFIG.LD_FIELD_ALIASES[key] ? CONFIG.LD_FIELD_ALIASES[key] : key;
-
     const addObject = function(obj) {
 
         if (!obj || !obj['@type']) {
@@ -1088,6 +1086,11 @@ export function unifyDate(date) {
     return null;
 };
 
+
+// Maps known lowercase/mixed-case LD field variants to their canonical camelCase spelling.
+export function camelCaseKeys(key) {
+    return CONFIG.LD_FIELD_ALIASES && CONFIG.LD_FIELD_ALIASES[key] ? CONFIG.LD_FIELD_ALIASES[key] : key;
+}
 
 export function lowerCaseKeys(obj, transform) {
     for (var k in obj) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1100,14 +1100,14 @@ export function lowerCaseKeys(obj, transform) {
         if (k === '__proto__' || k === 'constructor' || k === 'prototype') {
             continue;
         }
-        var transformedKey = transform ? transform (k) : k.toLowerCase();
+        var transformedKey = transform ? transform(k) : k.toLowerCase();
         if (transformedKey != k) {
             obj[transformedKey] = obj[k];
             delete obj[k];
             k = transformedKey;
         }
         if (typeof obj[k] == "object") {
-            lowerCaseKeys(obj[k]);
+            lowerCaseKeys(obj[k], transform);
         }
     }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1468,14 +1468,14 @@ function getWhitelistLogData(meta, oembed, uri) {
         if (ld) {
             var json = ld.videoobject || ld.mediaobject;
             if (!json) { // try to find video attached to main object
-                var mainObjWithVideo = ld && Object.values(ld).find((obj) => obj.video || obj.videoobject);
+                var mainObjWithVideo = ld && Object.values(ld).find((obj) => obj.video || obj.videoObject);
                 if (mainObjWithVideo) {
-                    json = mainObjWithVideo.video || mainObjWithVideo.videoobject;
+                    json = mainObjWithVideo.video || mainObjWithVideo.videoObject;
                 }
             }
 
             if (json) {
-                var embedURL = json.embedurl || json.embedUrl || json.embedURL || json.contenturl || json.contentUrl || json.contentURL;
+                var embedURL = json.embedUrl || json.contentUrl;
                 r.embedURL = isInterestingPlayer(embedURL, canonical);
             }
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -569,6 +569,8 @@ export function parseLDSource(ld, decode, uri, type_aliases) {
         }
     };
 
+    const camelCaseKeys = (key) => CONFIG.LD_FIELD_ALIASES && CONFIG.LD_FIELD_ALIASES[key] ? CONFIG.LD_FIELD_ALIASES[key] : key;
+
     const addObject = function(obj) {
 
         if (!obj || !obj['@type']) {
@@ -577,6 +579,8 @@ export function parseLDSource(ld, decode, uri, type_aliases) {
 
         const type = Array.isArray(obj['@type']) ? obj['@type'][0] : obj['@type'];
         const name = getName(type);
+
+        lowerCaseKeys(obj, camelCaseKeys);
 
         pushObj(name, obj);
     };
@@ -615,9 +619,9 @@ export function findMainLdObjectWithVideo(ld) {
     || (ld.tvclip && (ld.tvclip.video || ld.tvclip.videoobject));
     */
     if (!json) { // try to find video attached to main object
-        var mainObjWithVideo = ld && Object.values(ld).find((obj) => obj.video || obj.videoobject);
+        var mainObjWithVideo = ld && Object.values(ld).find((obj) => obj.video || obj.videoObject);
         if (mainObjWithVideo) {
-            json = mainObjWithVideo.video || mainObjWithVideo.videoobject;
+            json = mainObjWithVideo.video || mainObjWithVideo.videoObject;
         }
     }
 
@@ -1085,7 +1089,7 @@ export function unifyDate(date) {
 };
 
 
-export function lowerCaseKeys(obj) {
+export function lowerCaseKeys(obj, transform) {
     for (var k in obj) {
         if (!Object.prototype.hasOwnProperty.call(obj, k)) {
             // Skip inherited keys (e.g. from an already polluted prototype).
@@ -1096,11 +1100,11 @@ export function lowerCaseKeys(obj) {
         if (k === '__proto__' || k === 'constructor' || k === 'prototype') {
             continue;
         }
-        var lowerCaseKey = k.toLowerCase();
-        if (lowerCaseKey != k) {
-            obj[lowerCaseKey] = obj[k];
+        var transformedKey = transform ? transform (k) : k.toLowerCase();
+        if (transformedKey != k) {
+            obj[transformedKey] = obj[k];
             delete obj[k];
-            k = lowerCaseKey;
+            k = transformedKey;
         }
         if (typeof obj[k] == "object") {
             lowerCaseKeys(obj[k]);

--- a/plugins/domains/tmz.com.js
+++ b/plugins/domains/tmz.com.js
@@ -9,7 +9,7 @@ export default {
     // It's here mostly for tests
     getLinks: function(schemaVideoObject) {
 
-        var href = schemaVideoObject.embedURL || schemaVideoObject.embedUrl || schemaVideoObject.embedurl;
+        var href = schemaVideoObject.embedUrl;
 
         if (href) {
             return {

--- a/plugins/domains/twitch.tv/clips.twitch.tv.js
+++ b/plugins/domains/twitch.tv/clips.twitch.tv.js
@@ -12,7 +12,7 @@ export default {
 
         if (meta.ld && meta.ld.videoobject 
             && meta.twitter && meta.twitter.title === 'Twitch'
-            && /^https?:\/\/clips\.twitch\.tv\/embed\?clip=$/i.test(meta.ld.videoobject.embedurl)) {
+            && /^https?:\/\/clips\.twitch\.tv\/embed\?clip=$/i.test(meta.ld.videoobject.embedUrl)) {
 
             return cb({
                 responseStatusCode: 404

--- a/plugins/domains/twitch.tv/twitch.tv.js
+++ b/plugins/domains/twitch.tv/twitch.tv.js
@@ -73,7 +73,7 @@ export default {
 
     getData: function(url, og, schemaVideoObject) {
 
-        var embedUrl = schemaVideoObject.embedUrl || schemaVideoObject.embedURL || schemaVideoObject.embedurl;
+        var embedUrl = schemaVideoObject.embedUrl;
 
         if (/\/videos?\/(\d+)/i.test(embedUrl)) {
             embedUrl = /\/videos?\/(\d+)/i.test(embedUrl)

--- a/plugins/domains/usatoday.com.js
+++ b/plugins/domains/usatoday.com.js
@@ -16,7 +16,7 @@ export default {
 
     getData: function (urlMatch, schemaVideoObject, meta) {
 
-        const img_src = schemaVideoObject.thumbnailurl || meta.twitter && meta.twitter.image || meta.og && meta.og.image;
+        const img_src = schemaVideoObject.thumbnailUrl || meta.twitter && meta.twitter.image || meta.og && meta.og.image;
         const contentUrl = schemaVideoObject.contentUrl;
 
         if (img_src 

--- a/plugins/links/embedURL/embedURL.js
+++ b/plugins/links/embedURL/embedURL.js
@@ -71,7 +71,7 @@ export default {
 
         var links = [];
         
-        var thumbnailURL = schemaVideoObject.thumbnail || schemaVideoObject.thumbnailURL || schemaVideoObject.thumbnailUrl || schemaVideoObject.thumbnailurl;
+        var thumbnailURL = schemaVideoObject.thumbnail || schemaVideoObject.thumbnailUrl;
         if (thumbnailURL) {
             links.push({
                 href: thumbnailURL,
@@ -80,7 +80,7 @@ export default {
             });
         }
 
-        var contentURL = schemaVideoObject.contentURL || schemaVideoObject.contentUrl || schemaVideoObject.contenturl;
+        var contentURL = schemaVideoObject.contentUrl;
         if (contentURL) {
             var accept = ['video/*', CONFIG.T.stream_apple_mpegurl, CONFIG.T.stream_x_mpegurl];
             if (whitelistRecord.isAllowed('html-meta.embedURL', 'accept')) {
@@ -97,7 +97,7 @@ export default {
 
         if (whitelistRecord.isAllowed('html-meta.embedURL')) {
 
-            var href = schemaVideoObject.embedURL || schemaVideoObject.embedUrl || schemaVideoObject.embedurl;
+            var href = schemaVideoObject.embedUrl;
 
             if (href) {
                 var player = {

--- a/plugins/links/embedURL/embedURL.js
+++ b/plugins/links/embedURL/embedURL.js
@@ -60,6 +60,9 @@ export default {
                 }
             });
 
+            // Microdata bypasses parseLDSource, so field names need the same camelCase normalization applied here.
+            utils.lowerCaseKeys(result, utils.camelCaseKeys);
+
             return {
                 schemaVideoObject: result
             };

--- a/plugins/links/embedURL/ld-video.js
+++ b/plugins/links/embedURL/ld-video.js
@@ -14,7 +14,7 @@ export default {
 
         if (json) {
 
-            var video_src = json.embedurl || json.embedUrl || json.embedURL || json.contenturl || json.contentUrl || json.contentURL;
+            var video_src = json.embedUrl || json.contentUrl;
 
             if (/^<iframe.*<\/iframe>$/i.test(video_src)) {
                 
@@ -25,7 +25,7 @@ export default {
 
                 if ($iframe && $iframe.length == 1 && $iframe.attr('src')) {
 
-                    json.embedurl = $iframe.attr('src');
+                    json.embedUrl = $iframe.attr('src');
                     video_src = $iframe.attr('src'); // For KNOWN check below.
 
                     if (!json.width && $iframe.attr('width')) {

--- a/plugins/meta/ld-article.js
+++ b/plugins/meta/ld-article.js
@@ -17,7 +17,7 @@ export default {
         if (ld.article) {
             return {
                 title: clean(ld.article.headline),
-                category: clean(ld.article.articlesection),
+                category: clean(ld.article.articleSection),
                 description: clean(ld.article.description)
             }
         }

--- a/plugins/meta/ld-article.js
+++ b/plugins/meta/ld-article.js
@@ -31,7 +31,7 @@ export default {
 
             images.forEach(image => {
                 links.push({
-                    href: image.contenturl || image.url,
+                    href: image.contentUrl || image.url,
                     type: CONFIG.T.image,
                     rel: [CONFIG.R.thumbnail, CONFIG.R.ld],
                     alt: image.caption || image.name

--- a/plugins/meta/ld-product.js
+++ b/plugins/meta/ld-product.js
@@ -18,7 +18,7 @@ export default {
             }
             return {
                 price: ld.product.price,
-                currency: ld.product.currency_code || ld.product.currency || ld.product.priceCurrency || ld.product.pricecurrency,
+                currency: ld.product.priceCurrency || ld.product.currency,
                 brand: (ld.product.brand && ld.product.brand.name) || ld.product.brand,
                 category: ld.product.category,
                 availability: ld.product.availability,


### PR DESCRIPTION
Clean up LD field naming unification, avoid lowercasing everything to keep the spec and meaning